### PR TITLE
Improve existing tools & add unit tests

### DIFF
--- a/.changeset/rare-eyes-battle.md
+++ b/.changeset/rare-eyes-battle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/mcp-server": major
+---
+
+feat(mcp): added http streaming and improved existing tools with pagination support

--- a/README.md
+++ b/README.md
@@ -179,8 +179,20 @@ We are working on adding more APIs to the MCP server. If you need something spec
 ## Contributing
 
 1. Clone the repository
-2. Run `pnpm install` to install the dependencies
-3. Run `pnpm run build`
+2. Run `npm install` to install the dependencies
+3. Run `npm run build`
+
+### Running Tests
+
+```bash
+npm test
+```
+
+To run tests with coverage:
+
+```bash
+npm test:coverage
+```
 
 To use the build as your MCP server you can point your MCP client to the `dist` folder.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4208 @@
+{
+  "name": "@eventcatalog/mcp-server",
+  "version": "1.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@eventcatalog/mcp-server",
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.6.1",
+        "https-proxy-agent": "^7.0.6",
+        "mcps-logger": "^1.0.0",
+        "node-fetch": "^3.3.2",
+        "zod": "^3.24.2"
+      },
+      "bin": {
+        "eventcatalog-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@changesets/cli": "^2.28.1",
+        "@types/node": "^22.13.10",
+        "prettier": "^3.5.3",
+        "shx": "^0.3.4",
+        "typescript": "^5.7.3",
+        "vitest": "^3.0.9"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.14.tgz",
+      "integrity": "sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/config": "^3.1.2",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.startcase": "^4.4.0",
+        "outdent": "^0.5.0",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
+      "integrity": "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.29.8",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz",
+      "integrity": "sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^7.0.14",
+        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.2",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/get-release-plan": "^4.0.14",
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.6",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@manypkg/get-packages": "^1.1.3",
+        "ansi-colors": "^4.1.3",
+        "ci-info": "^3.7.0",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "mri": "^1.2.0",
+        "p-limit": "^2.2.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
+      "integrity": "sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
+      "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "picocolors": "^1.1.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.14.tgz",
+      "integrity": "sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/config": "^3.1.2",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.6",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.2.tgz",
+      "integrity": "sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "js-yaml": "^4.1.1"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.6.tgz",
+      "integrity": "sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.2",
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@types/node": "^12.7.1",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
+        "read-yaml-file": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.1.tgz",
+      "integrity": "sha512-YTg4v6bKSst8EJM8NXHC3nGm8kgHD08IbIBbognUeLAgGLVgLpYrgQswzLQd4OyTL4l614ejhqsDrV1//t02Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-id": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
+      "integrity": "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcps-logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mcps-logger/-/mcps-logger-1.0.0.tgz",
+      "integrity": "sha512-oFxJLckvamGMIhZWTAy/IBMl84xy1qaobWKt3uJomev4N2D+xDvNNxrt6oqk4BCThSGn33HqEyO77rJfew7K1w==",
+      "license": "MIT",
+      "bin": {
+        "mcps-logger": "dist/server.js"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.5",
+        "js-yaml": "^3.6.1",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
+      "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,13 +28,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.24.1",
+    "express": "^5.2.1",
     "https-proxy-agent": "^7.0.6",
-    "mcps-logger": "^1.0.0",
     "node-fetch": "^3.3.2",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@changesets/cli": "^2.28.1",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.13.10",
     "prettier": "^3.5.3",
     "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "release": "changeset publish"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.6.1",
+    "@modelcontextprotocol/sdk": "1.24.1",
     "https-proxy-agent": "^7.0.6",
     "mcps-logger": "^1.0.0",
     "node-fetch": "^3.3.2",
-    "zod": "^3.24.2"
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@changesets/cli": "^2.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.6.1
-        version: 1.6.1
+        specifier: 1.24.1
+        version: 1.24.1(zod@4.1.13)
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.1.13
+        version: 4.1.13
     devDependencies:
       '@changesets/cli':
         specifier: ^2.28.1
@@ -263,9 +263,15 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/sdk@1.6.1':
-    resolution: {integrity: sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==}
+  '@modelcontextprotocol/sdk@1.24.1':
+    resolution: {integrity: sha512-YTg4v6bKSst8EJM8NXHC3nGm8kgHD08IbIBbognUeLAgGLVgLpYrgQswzLQd4OyTL4l614ejhqsDrV1//t02Qw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -420,6 +426,17 @@ packages:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -446,8 +463,8 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  body-parser@2.1.0:
-    resolution: {integrity: sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==}
+  body-parser@2.2.1:
+    resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
 
   brace-expansion@1.1.11:
@@ -491,9 +508,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  content-disposition@1.0.0:
-    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
-    engines: {node: '>= 0.6'}
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -503,8 +520,8 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
-  cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cors@2.8.5:
@@ -519,8 +536,8 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  debug@4.3.6:
-    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -528,8 +545,8 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -544,10 +561,6 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-
-  destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -607,26 +620,26 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventsource-parser@3.0.0:
-    resolution: {integrity: sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==}
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
-  eventsource@3.0.5:
-    resolution: {integrity: sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==}
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   expect-type@1.2.0:
     resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@7.5.0:
-    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
     engines: {node: '>= 16'}
     peerDependencies:
-      express: ^4.11 || 5 || ^5.0.0-beta.1
+      express: '>= 4.11'
 
-  express@5.0.1:
-    resolution: {integrity: sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==}
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
@@ -636,9 +649,15 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -651,9 +670,9 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@2.1.0:
-    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
-    engines: {node: '>= 0.8'}
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -665,10 +684,6 @@ packages:
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -729,8 +744,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  http-errors@2.0.0:
-    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   https-proxy-agent@7.0.6:
@@ -745,12 +760,8 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.5.2:
-    resolution: {integrity: sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -802,9 +813,15 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -842,29 +859,17 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.53.0:
-    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.0:
-    resolution: {integrity: sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==}
-    engines: {node: '>= 0.6'}
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -875,9 +880,6 @@ packages:
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-
-  ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -963,9 +965,8 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-to-regexp@8.2.0:
-    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
-    engines: {node: '>=16'}
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -989,8 +990,8 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pkce-challenge@4.1.0:
-    resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
   postcss@8.5.3:
@@ -1011,10 +1012,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
-
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -1029,9 +1026,9 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  raw-body@3.0.0:
-    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
-    engines: {node: '>= 0.8'}
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1043,6 +1040,10 @@ packages:
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1062,15 +1063,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  router@2.1.0:
-    resolution: {integrity: sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==}
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1080,12 +1078,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@1.1.0:
-    resolution: {integrity: sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==}
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
 
-  serve-static@2.1.0:
-    resolution: {integrity: sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==}
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
 
   setprototypeof@1.2.0:
@@ -1149,8 +1147,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  statuses@2.0.1:
-    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.8.1:
@@ -1202,8 +1200,8 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  type-is@2.0.0:
-    resolution: {integrity: sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==}
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typescript@5.8.2:
@@ -1221,10 +1219,6 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-
-  utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1320,13 +1314,13 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  zod-to-json-schema@3.24.3:
-    resolution: {integrity: sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==}
+  zod-to-json-schema@3.25.0:
+    resolution: {integrity: sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: ^3.25 || ^4
 
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+  zod@4.1.13:
+    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
 snapshots:
 
@@ -1569,17 +1563,22 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.6.1':
+  '@modelcontextprotocol/sdk@1.24.1(zod@4.1.13)':
     dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
       cors: 2.8.5
-      eventsource: 3.0.5
-      express: 5.0.1
-      express-rate-limit: 7.5.0(express@5.0.1)
-      pkce-challenge: 4.1.0
-      raw-body: 3.0.0
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.0(zod@4.1.13)
     transitivePeerDependencies:
       - supports-color
 
@@ -1702,10 +1701,21 @@ snapshots:
 
   accepts@2.0.0:
     dependencies:
-      mime-types: 3.0.0
+      mime-types: 3.0.2
       negotiator: 1.0.0
 
   agent-base@7.1.3: {}
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -1725,17 +1735,17 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  body-parser@2.1.0:
+  body-parser@2.2.1:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
-      http-errors: 2.0.0
-      iconv-lite: 0.5.2
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
       on-finished: 2.4.1
       qs: 6.14.0
-      raw-body: 3.0.0
-      type-is: 2.0.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -1778,15 +1788,13 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  content-disposition@1.0.0:
-    dependencies:
-      safe-buffer: 5.2.1
+  content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
 
   cookie-signature@1.2.2: {}
 
-  cookie@0.7.1: {}
+  cookie@0.7.2: {}
 
   cors@2.8.5:
     dependencies:
@@ -1801,19 +1809,17 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  debug@4.3.6:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
 
   depd@2.0.0: {}
-
-  destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -1884,51 +1890,47 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventsource-parser@3.0.0: {}
+  eventsource-parser@3.0.6: {}
 
-  eventsource@3.0.5:
+  eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.0
+      eventsource-parser: 3.0.6
 
   expect-type@1.2.0: {}
 
-  express-rate-limit@7.5.0(express@5.0.1):
+  express-rate-limit@7.5.1(express@5.2.1):
     dependencies:
-      express: 5.0.1
+      express: 5.2.1
 
-  express@5.0.1:
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.1.0
-      content-disposition: 1.0.0
+      body-parser: 2.2.1
+      content-disposition: 1.0.1
       content-type: 1.0.5
-      cookie: 0.7.1
+      cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.3.6
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.0
+      finalhandler: 2.1.1
       fresh: 2.0.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 2.0.0
-      methods: 1.1.2
-      mime-types: 3.0.0
+      mime-types: 3.0.2
       on-finished: 2.4.1
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.14.0
       range-parser: 1.2.1
-      router: 2.1.0
-      safe-buffer: 5.2.1
-      send: 1.1.0
-      serve-static: 2.1.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 2.0.0
-      utils-merge: 1.0.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.2
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1941,6 +1943,8 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1948,6 +1952,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-uri@3.1.0: {}
 
   fastq@1.19.1:
     dependencies:
@@ -1962,14 +1968,14 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.0:
+  finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1983,8 +1989,6 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
-
-  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -2057,12 +2061,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  http-errors@2.0.0:
+  http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
       inherits: 2.0.4
       setprototypeof: 1.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       toidentifier: 1.0.1
 
   https-proxy-agent@7.0.6:
@@ -2078,11 +2082,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.5.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.6.3:
+  iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -2121,10 +2121,14 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jose@6.1.3: {}
+
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  json-schema-traverse@1.0.0: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -2152,24 +2156,16 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  methods@1.1.2: {}
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0: {}
+  mime-db@1.54.0: {}
 
-  mime-db@1.53.0: {}
-
-  mime-types@2.1.35:
+  mime-types@3.0.2:
     dependencies:
-      mime-db: 1.52.0
-
-  mime-types@3.0.0:
-    dependencies:
-      mime-db: 1.53.0
+      mime-db: 1.54.0
 
   minimatch@3.1.2:
     dependencies:
@@ -2178,8 +2174,6 @@ snapshots:
   minimist@1.2.8: {}
 
   mri@1.2.0: {}
-
-  ms@2.1.2: {}
 
   ms@2.1.3: {}
 
@@ -2241,7 +2235,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@8.2.0: {}
+  path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -2255,7 +2249,7 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pkce-challenge@4.1.0: {}
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.3:
     dependencies:
@@ -2272,10 +2266,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.13.0:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -2286,11 +2276,11 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@3.0.0:
+  raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
       unpipe: 1.0.0
 
   read-yaml-file@1.1.0:
@@ -2305,6 +2295,8 @@ snapshots:
       resolve: 1.22.10
 
   regenerator-runtime@0.14.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -2341,45 +2333,46 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.36.0
       fsevents: 2.3.3
 
-  router@2.1.0:
+  router@2.2.0:
     dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.2.0
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.2.1: {}
-
   safer-buffer@2.1.2: {}
 
   semver@7.7.1: {}
 
-  send@1.1.0:
+  send@1.2.0:
     dependencies:
-      debug: 4.3.6
-      destroy: 1.2.0
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime-types: 2.1.35
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.1.0:
+  serve-static@2.2.0:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.1.0
+      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2447,7 +2440,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.1: {}
+  statuses@2.0.2: {}
 
   std-env@3.8.1: {}
 
@@ -2481,11 +2474,11 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  type-is@2.0.0:
+  type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
-      mime-types: 3.0.0
+      mime-types: 3.0.2
 
   typescript@5.8.2: {}
 
@@ -2494,8 +2487,6 @@ snapshots:
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
-
-  utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
 
@@ -2580,8 +2571,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  zod-to-json-schema@3.24.3(zod@3.24.2):
+  zod-to-json-schema@3.25.0(zod@4.1.13):
     dependencies:
-      zod: 3.24.2
+      zod: 4.1.13
 
-  zod@3.24.2: {}
+  zod@4.1.13: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.24.1
         version: 1.24.1(zod@4.1.13)
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6
-      mcps-logger:
-        specifier: ^1.0.0
-        version: 1.0.0
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -27,6 +27,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.28.1
         version: 2.28.1
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -380,14 +383,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/express-serve-static-core@5.1.0':
+    resolution: {integrity: sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
+
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@vitest/expect@3.0.9':
     resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
@@ -842,10 +872,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  mcps-logger@1.0.0:
-    resolution: {integrity: sha512-oFxJLckvamGMIhZWTAy/IBMl84xy1qaobWKt3uJomev4N2D+xDvNNxrt6oqk4BCThSGn33HqEyO77rJfew7K1w==}
-    hasBin: true
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -1651,13 +1677,50 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.36.0':
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.13.10
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.13.10
+
   '@types/estree@1.0.6': {}
+
+  '@types/express-serve-static-core@5.1.0':
+    dependencies:
+      '@types/node': 22.13.10
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.0
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/node@12.20.55': {}
 
   '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.13.10
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.13.10
 
   '@vitest/expect@3.0.9':
     dependencies:
@@ -2147,8 +2210,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   math-intrinsics@1.1.0: {}
-
-  mcps-logger@1.0.0: {}
 
   media-typer@1.1.0: {}
 

--- a/scripts/inspector.sh
+++ b/scripts/inspector.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.."
+
+# Build the server
+npm run build
+
+# Run MCP Inspector with URL and license key as arguments
+npx @modelcontextprotocol/inspector -- node dist/index.js https://demo.eventcatalog.dev

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,54 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+export interface ServerConfig {
+  eventCatalogUrl: string;
+  licenseKey: string;
+  transport: 'stdio' | 'http';
+  port: number;
+  basePath: string;
+}
+
+/**
+ * Parse and validate configuration from command line arguments and environment variables
+ */
+export function parseConfig(): ServerConfig {
+  const eventCatalogUrl = process.argv[2] || process.env.EVENTCATALOG_URL;
+  const licenseKey = process.argv[3] || process.env.EVENTCATALOG_SCALE_LICENSE_KEY;
+  const transport = (process.env.MCP_TRANSPORT as 'stdio' | 'http') || 'stdio';
+  const port = parseInt(process.argv[5] || process.env.PORT || '3000', 10);
+  const basePath = process.argv[6] || process.env.BASE_PATH || '/';
+
+  // Validate required fields
+  if (!eventCatalogUrl) {
+    throw new McpError(ErrorCode.InvalidParams, 'EVENTCATALOG_URL is not set');
+  }
+
+  if (!licenseKey) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'EVENTCATALOG_SCALE_LICENSE_KEY is not set. You can get a license key from https://eventcatalog.cloud'
+    );
+  }
+
+  // Validate URL format
+  try {
+    new URL(eventCatalogUrl);
+  } catch (error) {
+    console.error('EVENTCATALOG_URL is not a valid URL', error);
+    throw new McpError(ErrorCode.InvalidParams, 'EVENTCATALOG_URL is not a valid URL');
+  }
+
+  // Validate port
+  if (isNaN(port)) {
+    throw new McpError(ErrorCode.InvalidParams, 'PORT is not a valid integer');
+  }
+
+  // Set environment variables for backward compatibility
+  process.env.EVENTCATALOG_URL = eventCatalogUrl;
+  process.env.EVENTCATALOG_SCALE_LICENSE_KEY = licenseKey;
+  process.env.MCP_TRANSPORT = transport;
+  process.env.PORT = port.toString();
+  process.env.BASE_PATH = basePath;
+
+  return { eventCatalogUrl, licenseKey, transport, port, basePath };
+}

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -1,0 +1,50 @@
+/**
+ * MCP error code for invalid cursor (Invalid params)
+ */
+export const INVALID_CURSOR_ERROR_CODE = -32602;
+
+/**
+ * Error thrown when cursor is invalid
+ */
+export class InvalidCursorError extends Error {
+  readonly code = INVALID_CURSOR_ERROR_CODE;
+
+  constructor(message = 'Invalid or malformed cursor') {
+    super(message);
+    this.name = 'InvalidCursorError';
+  }
+}
+
+/**
+ * Encode position to opaque cursor string.
+ * Uses base64url for URL-safe encoding.
+ */
+export function encodeCursor(position: number): string {
+  return Buffer.from(String(position)).toString('base64url');
+}
+
+/**
+ * Decode cursor string to position.
+ * Returns null if cursor is invalid.
+ */
+export function decodeCursor(cursor: string): number | null {
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    const position = parseInt(decoded, 10);
+    return isNaN(position) || position < 0 ? null : position;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode cursor string to position, throwing if invalid.
+ * Use this when you want to return MCP-compliant error.
+ */
+export function decodeCursorOrThrow(cursor: string): number {
+  const position = decodeCursor(cursor);
+  if (position === null) {
+    throw new InvalidCursorError();
+  }
+  return position;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,44 +1,55 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import 'mcps-logger/console';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { parseConfig } from './config.js';
 import { registerTools } from './tools/index.js';
-import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { registerResources } from './resources/index.js';
+import { startHttpServer, startStdioServer } from './servers/index.js';
 import checkLicense from './license/check-license.js';
+import pkg from '../package.json' with { type: 'json' };
 
-// Create an MCP server
-const server = new McpServer({
-  name: 'EventCatalog MCP Server',
-  version: '1.0.0',
+/**
+ * Initialize the MCP server with tools and resources
+ */
+function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'EventCatalog MCP Server',
+    version: pkg.version,
+  });
+
+  registerTools(server);
+  registerResources(server);
+
+  return server;
+}
+
+/**
+ * Main entry point
+ */
+async function main(): Promise<void> {
+  const config = parseConfig();
+
+  // Validate license
+  await checkLicense('@eventcatalog/eventcatalog-scale', config.licenseKey);
+
+  // Create and initialize server
+  const server = createMcpServer();
+
+  // Start appropriate transport
+  switch (config.transport) {
+    case 'stdio':
+      await startStdioServer(server);
+      break;
+    case 'http':
+      startHttpServer(server, config);
+      break;
+    default:
+      throw new McpError(ErrorCode.InvalidParams, `Invalid MCP transport: ${config.transport}`);
+  }
+}
+
+// Run the server
+main().catch((error) => {
+  console.error('Fatal error starting server:', error);
+  process.exit(1);
 });
-
-process.env.EVENTCATALOG_URL = process.argv[2] || process.env.EVENTCATALOG_URL;
-process.env.EVENTCATALOG_SCALE_LICENSE_KEY = process.argv[3] || process.env.EVENTCATALOG_SCALE_LICENSE_KEY;
-
-if (!process.env.EVENTCATALOG_URL || !process.argv[2]) {
-  throw new McpError(ErrorCode.InvalidParams, 'EVENTCATALOG_URL is not set');
-}
-
-if (!process.env.EVENTCATALOG_SCALE_LICENSE_KEY || !process.argv[3]) {
-  throw new McpError(
-    ErrorCode.InvalidParams,
-    'EVENTCATALOG_SCALE_LICENSE_KEY is not set. You can get a license key from https://eventcatalog.cloud'
-  );
-}
-
-try {
-  new URL(process.env.EVENTCATALOG_URL);
-} catch (error) {
-  console.error('EVENTCATALOG_URL is not a valid URL', error);
-  throw new McpError(ErrorCode.InvalidParams, 'EVENTCATALOG_URL is not a valid URL');
-}
-
-await checkLicense('@eventcatalog/eventcatalog-scale', process.env.EVENTCATALOG_SCALE_LICENSE_KEY);
-
-registerTools(server);
-registerResources(server);
-
-const transport = new StdioServerTransport();
-await server.connect(transport);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,119 @@
+import type {
+  ParsedResource,
+  EventResource,
+  CommandResource,
+  QueryResource,
+  ServiceResource,
+  DomainResource,
+  FlowResource,
+  EntityResource,
+  ChannelResource,
+  TeamResource,
+  UserResource,
+  DocResource,
+} from './types.js';
+
+type VersionedType = EventResource['type'] | CommandResource['type'] | QueryResource['type'] |
+  ServiceResource['type'] | DomainResource['type'] | FlowResource['type'] |
+  EntityResource['type'] | ChannelResource['type'];
+
+type UnversionedType = TeamResource['type'] | UserResource['type'] | DocResource['type'];
+
+/**
+ * Section header to resource type mapping
+ */
+const VERSIONED_SECTIONS: Record<string, VersionedType> = {
+  'events': 'event',
+  'commands': 'command',
+  'queries': 'query',
+  'services': 'service',
+  'domains': 'domain',
+  'flows': 'flow',
+  'entities': 'entity',
+  'channels': 'channel',
+};
+
+const UNVERSIONED_SECTIONS: Record<string, UnversionedType> = {
+  'teams': 'team',
+  'users': 'user',
+  'custom docs': 'doc',
+};
+
+/**
+ * Parse llms.txt content into structured resources.
+ */
+export function parseLlmsTxt(text: string): ParsedResource[] {
+  const resources: ParsedResource[] = [];
+  const lines = text.split('\n');
+
+  let currentSection: string | null = null;
+
+  for (const line of lines) {
+    // Section header: ## Events, ## Teams, etc.
+    if (line.startsWith('## ')) {
+      currentSection = line.slice(3).trim().toLowerCase();
+      continue;
+    }
+
+    // Resource line: - [...](...) - ...
+    if (line.startsWith('- [') && currentSection) {
+      const versionedType = VERSIONED_SECTIONS[currentSection];
+      const unversionedType = UNVERSIONED_SECTIONS[currentSection];
+
+      if (versionedType) {
+        const resource = parseVersionedLine(line, versionedType);
+        if (resource) resources.push(resource);
+      } else if (unversionedType) {
+        const resource = parseUnversionedLine(line, unversionedType);
+        if (resource) resources.push(resource);
+      }
+    }
+  }
+
+  return resources;
+}
+
+/**
+ * Parse versioned resource line.
+ * Format: - [Name - ID - Version](url) - Summary
+ */
+function parseVersionedLine(line: string, type: VersionedType): ParsedResource | null {
+  const match = line.match(/^- \[([^\]]+)\]\(([^)]+)\)(?:\s*-\s*(.*))?$/);
+  if (!match) return null;
+
+  const [, bracketContent, url, summary] = match;
+  const parts = bracketContent.split(' - ');
+
+  if (parts.length < 3) return null;
+
+  const version = parts[parts.length - 1].trim();
+  const id = parts[parts.length - 2].trim();
+  const name = parts.slice(0, -2).join(' - ').trim();
+
+  return {
+    type,
+    id,
+    name,
+    version,
+    summary: summary?.trim(),
+    url: url.trim(),
+  } as ParsedResource;
+}
+
+/**
+ * Parse non-versioned resource line (teams, users, docs).
+ * Format: - [ID](url) - Name/Summary
+ */
+function parseUnversionedLine(line: string, type: UnversionedType): ParsedResource | null {
+  const match = line.match(/^- \[([^\]]+)\]\(([^)]+)\)(?:\s*-\s*(.*))?$/);
+  if (!match) return null;
+
+  const [, id, url, nameOrSummary] = match;
+
+  return {
+    type,
+    id: id.trim(),
+    name: nameOrSummary?.trim() || id.trim(),
+    url: url.trim(),
+  } as ParsedResource;
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -13,9 +13,15 @@ import type {
   DocResource,
 } from './types.js';
 
-type VersionedType = EventResource['type'] | CommandResource['type'] | QueryResource['type'] |
-  ServiceResource['type'] | DomainResource['type'] | FlowResource['type'] |
-  EntityResource['type'] | ChannelResource['type'];
+type VersionedType =
+  | EventResource['type']
+  | CommandResource['type']
+  | QueryResource['type']
+  | ServiceResource['type']
+  | DomainResource['type']
+  | FlowResource['type']
+  | EntityResource['type']
+  | ChannelResource['type'];
 
 type UnversionedType = TeamResource['type'] | UserResource['type'] | DocResource['type'];
 
@@ -23,19 +29,19 @@ type UnversionedType = TeamResource['type'] | UserResource['type'] | DocResource
  * Section header to resource type mapping
  */
 const VERSIONED_SECTIONS: Record<string, VersionedType> = {
-  'events': 'event',
-  'commands': 'command',
-  'queries': 'query',
-  'services': 'service',
-  'domains': 'domain',
-  'flows': 'flow',
-  'entities': 'entity',
-  'channels': 'channel',
+  events: 'event',
+  commands: 'command',
+  queries: 'query',
+  services: 'service',
+  domains: 'domain',
+  flows: 'flow',
+  entities: 'entity',
+  channels: 'channel',
 };
 
 const UNVERSIONED_SECTIONS: Record<string, UnversionedType> = {
-  'teams': 'team',
-  'users': 'user',
+  teams: 'team',
+  users: 'user',
   'custom docs': 'doc',
 };
 

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -5,11 +5,12 @@ import type { ResourceKind } from '../types.js';
 
 /**
  * Fetch and filter resources by type, return JSON
+ * Returns { resources: [...] } to match find_resources tool format
  */
 export async function getResourcesByType(type: ResourceKind | 'all'): Promise<string> {
-  const resources = await fetchParsedResources();
-  const filtered = filterByType(resources, type);
-  return JSON.stringify(filtered, null, 2);
+  const allResources = await fetchParsedResources();
+  const filtered = filterByType(allResources, type);
+  return JSON.stringify({ resources: filtered }, null, 2);
 }
 
 /**

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,11 +1,10 @@
-import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { fetchParsedResources } from '../utils/fetch.js';
 import { filterByType } from '../utils/filter.js';
 import type { ResourceKind } from '../types.js';
 
 /**
  * Fetch and filter resources by type, return JSON
- * Returns { resources: [...] } to match find_resources tool format
  */
 export async function getResourcesByType(type: ResourceKind | 'all'): Promise<string> {
   const allResources = await fetchParsedResources();
@@ -14,92 +13,77 @@ export async function getResourcesByType(type: ResourceKind | 'all'): Promise<st
 }
 
 /**
- * Map URI path to resource type
+ * Static list resources configuration
  */
-function uriToType(uri: string): ResourceKind | 'all' {
-  const path = uri.replace('eventcatalog://', '');
-  const typeMap: Record<string, ResourceKind | 'all'> = {
-    all: 'all',
-    events: 'event',
-    domains: 'domain',
-    services: 'service',
-    queries: 'query',
-    commands: 'command',
-    flows: 'flow',
-    teams: 'team',
-    users: 'user',
-    entities: 'entity',
-    channels: 'channel',
-    docs: 'doc',
-  };
-  return typeMap[path] ?? 'all';
-}
-
-const resources = [
+const listResources = [
   {
     name: 'All Resources in EventCatalog',
     uri: 'eventcatalog://all',
     description: 'All messages, domains and services in EventCatalog',
-    mimeType: 'application/json',
+    type: 'all' as const,
   },
   {
     name: 'All Events in EventCatalog',
     uri: 'eventcatalog://events',
     description: 'All events in EventCatalog',
-    mimeType: 'application/json',
+    type: 'event' as const,
   },
   {
     name: 'All Domains in EventCatalog',
     uri: 'eventcatalog://domains',
     description: 'All domains in EventCatalog',
-    mimeType: 'application/json',
+    type: 'domain' as const,
   },
   {
     name: 'All Services in EventCatalog',
     uri: 'eventcatalog://services',
     description: 'All services in EventCatalog',
-    mimeType: 'application/json',
+    type: 'service' as const,
   },
   {
     name: 'All Queries in EventCatalog',
     uri: 'eventcatalog://queries',
     description: 'All queries in EventCatalog',
-    mimeType: 'application/json',
+    type: 'query' as const,
   },
   {
     name: 'All Commands in EventCatalog',
     uri: 'eventcatalog://commands',
     description: 'All commands in EventCatalog',
-    mimeType: 'application/json',
+    type: 'command' as const,
   },
   {
     name: 'All Flows in EventCatalog',
     uri: 'eventcatalog://flows',
     description: 'All flows in EventCatalog',
-    mimeType: 'application/json',
+    type: 'flow' as const,
   },
   {
     name: 'All Teams in EventCatalog',
     uri: 'eventcatalog://teams',
     description: 'All teams in EventCatalog',
-    mimeType: 'application/json',
+    type: 'team' as const,
   },
   {
     name: 'All Users in EventCatalog',
     uri: 'eventcatalog://users',
     description: 'All users in EventCatalog',
-    mimeType: 'application/json',
+    type: 'user' as const,
   },
 ];
 
 export function registerResources(server: McpServer) {
-  resources.forEach((resource) => {
-    server.resource(resource.name, new ResourceTemplate(resource.uri, { list: undefined }), async (uri) => {
-      const type = uriToType(uri.href);
-      const json = await getResourcesByType(type);
-      return {
-        contents: [{ uri: uri.href, text: json, mimeType: 'application/json' }],
-      };
-    });
-  });
+  for (const resource of listResources) {
+    server.registerResource(
+      resource.name,
+      resource.uri,
+      { description: resource.description, mimeType: 'application/json' },
+      async (uri) => {
+        const json = await getResourcesByType(resource.type);
+        return {
+          contents: [{ uri: uri.href, text: json, mimeType: 'application/json' }],
+        };
+      }
+    );
+  }
 }

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -1,0 +1,54 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express, { type Express, type Request, type Response } from 'express';
+import type { ServerConfig } from '../config.js';
+
+/**
+ * Handle MCP requests over HTTP
+ */
+async function handleHttpRequest(server: McpServer, req: Request, res: Response): Promise<void> {
+  try {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    res.on('close', () => {
+      transport.close();
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error',
+        },
+        id: null,
+      });
+    }
+  }
+}
+
+/**
+ * Start HTTP server
+ */
+export function startHttpServer(server: McpServer, config: ServerConfig): void {
+  const app: Express = express();
+
+  app.use(config.basePath, async (req, res) => {
+    await handleHttpRequest(server, req, res);
+  });
+
+  app
+    .listen(config.port, () => {
+      console.log(`EventCatalog MCP Server running on port ${config.port} at ${config.basePath}`);
+    })
+    .on('error', (error) => {
+      console.error('Error starting server:', error);
+      process.exit(1);
+    });
+}

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -1,0 +1,2 @@
+export { startHttpServer } from './http.js';
+export { startStdioServer } from './stdio.js';

--- a/src/servers/stdio.ts
+++ b/src/servers/stdio.ts
@@ -1,0 +1,11 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+/**
+ * Start stdio server
+ */
+export async function startStdioServer(server: McpServer): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.log('EventCatalog MCP Server running on stdio');
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -69,7 +69,7 @@ export function filterAndPaginateResources(
     startIndex = decoded;
   }
 
-  const pageSize = DEFAULT_PAGE_SIZE;
+  const pageSize = process.env.PAGE_SIZE ? parseInt(process.env.PAGE_SIZE) : DEFAULT_PAGE_SIZE;
   const endIndex = startIndex + pageSize;
   const pageResources = filtered.slice(startIndex, endIndex);
   const hasMore = endIndex < filtered.length;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,7 +6,7 @@ import { prompt as createFlowPrompt } from './flows.js';
 import path, { dirname } from 'path';
 import fs from 'fs';
 import { encodeCursor, decodeCursor, InvalidCursorError } from '../cursor.js';
-import { fetchParsedResources, fetchLlmsTxt } from '../utils/fetch.js';
+import { fetchParsedResources, fetchOwnerById } from '../utils/fetch.js';
 import { filterByType, filterBySearch } from '../utils/filter.js';
 import type { ParsedResource, ResourceFilter } from '../types.js';
 
@@ -314,10 +314,28 @@ const handlers = {
       content: [{ type: 'text', text: text }],
     };
   },
-  find_owners: async (params: any) => {
-    const text = await fetchLlmsTxt();
+  find_owners: async (params: { id: string }) => {
+    const ownerId = params.id?.trim();
+
+    if (!ownerId) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ error: 'Owner id is required' }) }],
+        isError: true,
+      };
+    }
+
+    const result = await fetchOwnerById(ownerId);
+
+    if ('error' in result) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: true,
+      };
+    }
+
+    // Return markdown content directly
     return {
-      content: [{ type: 'text', text: text }],
+      content: [{ type: 'text', text: result.content }],
     };
   },
   eventstorm_to_eventcatalog: async (params: any) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,35 @@
+// ============================================================================
+// Resource Kind Types
+// ============================================================================
+
 /**
- * Base fields for versioned resources
+ * Versioned resource kinds (have id, name, version)
  */
-interface VersionedBase {
+export type VersionedKind = 'event' | 'command' | 'query' | 'service' | 'domain' | 'flow' | 'entity' | 'channel';
+
+/**
+ * Unversioned resource kinds (have id, name, no version)
+ */
+export type UnversionedKind = 'team' | 'user' | 'doc';
+
+/**
+ * All resource kinds
+ */
+export type ResourceKind = VersionedKind | UnversionedKind;
+
+/**
+ * Filter type including 'all'
+ */
+export type ResourceFilter = ResourceKind | 'all';
+
+// ============================================================================
+// List Results (from llms.txt - summary info)
+// ============================================================================
+
+/**
+ * Base fields for versioned list results
+ */
+interface VersionedListBase {
   id: string;
   name: string;
   version: string;
@@ -10,93 +38,264 @@ interface VersionedBase {
 }
 
 /**
- * Base fields for non-versioned resources
+ * Base fields for unversioned list results
  */
-interface UnversionedBase {
+interface UnversionedListBase {
   id: string;
   name: string;
   summary?: string;
   url: string;
 }
 
-// Versioned resource types
+// Versioned list result types
 
-export interface EventResource extends VersionedBase {
+export interface EventListResult extends VersionedListBase {
   type: 'event';
 }
 
-export interface CommandResource extends VersionedBase {
+export interface CommandListResult extends VersionedListBase {
   type: 'command';
 }
 
-export interface QueryResource extends VersionedBase {
+export interface QueryListResult extends VersionedListBase {
   type: 'query';
 }
 
-export interface ServiceResource extends VersionedBase {
+export interface ServiceListResult extends VersionedListBase {
   type: 'service';
 }
 
-export interface DomainResource extends VersionedBase {
+export interface DomainListResult extends VersionedListBase {
   type: 'domain';
 }
 
-export interface FlowResource extends VersionedBase {
+export interface FlowListResult extends VersionedListBase {
   type: 'flow';
 }
 
-export interface EntityResource extends VersionedBase {
+export interface EntityListResult extends VersionedListBase {
   type: 'entity';
 }
 
-export interface ChannelResource extends VersionedBase {
+export interface ChannelListResult extends VersionedListBase {
   type: 'channel';
 }
 
-// Non-versioned resource types
+// Unversioned list result types
 
-export interface TeamResource extends UnversionedBase {
+export interface TeamListResult extends UnversionedListBase {
   type: 'team';
 }
 
-export interface UserResource extends UnversionedBase {
+export interface UserListResult extends UnversionedListBase {
   type: 'user';
 }
 
-export interface DocResource extends UnversionedBase {
+export interface DocListResult extends UnversionedListBase {
   type: 'doc';
 }
 
 /**
- * Union of all resource types
+ * Union of all versioned list result types
  */
-export type ParsedResource =
-  | EventResource
-  | CommandResource
-  | QueryResource
-  | ServiceResource
-  | DomainResource
-  | FlowResource
-  | EntityResource
-  | ChannelResource
-  | TeamResource
-  | UserResource
-  | DocResource;
+export type VersionedListResult =
+  | EventListResult
+  | CommandListResult
+  | QueryListResult
+  | ServiceListResult
+  | DomainListResult
+  | FlowListResult
+  | EntityListResult
+  | ChannelListResult;
 
 /**
- * Resource kind literals
+ * Union of all unversioned list result types
  */
-export type ResourceKind = ParsedResource['type'];
+export type UnversionedListResult = TeamListResult | UserListResult | DocListResult;
 
 /**
- * Filter type including 'all'
+ * Union of all list result types (from llms.txt)
  */
-export type ResourceFilter = ResourceKind | 'all';
+export type ListResult = VersionedListResult | UnversionedListResult;
+
+// ============================================================================
+// Full Results (from fetching .mdx files - includes content)
+// ============================================================================
 
 /**
- * Paginated response following MCP conventions
+ * Valid MIME types for resource content
  */
-export interface PaginatedResult {
-  resources: ParsedResource[];
+export type ResourceMimeType = 'text/markdown' | 'text/plain' | 'application/json';
+
+/**
+ * Base fields for versioned full results (includes content)
+ */
+interface VersionedFullBase extends VersionedListBase {
+  content: string;
+  mimeType: ResourceMimeType;
+}
+
+/**
+ * Base fields for unversioned full results (includes content)
+ */
+interface UnversionedFullBase extends UnversionedListBase {
+  content: string;
+  mimeType: ResourceMimeType;
+}
+
+// Versioned full result types
+
+export interface EventFullResult extends VersionedFullBase {
+  type: 'event';
+}
+
+export interface CommandFullResult extends VersionedFullBase {
+  type: 'command';
+}
+
+export interface QueryFullResult extends VersionedFullBase {
+  type: 'query';
+}
+
+export interface ServiceFullResult extends VersionedFullBase {
+  type: 'service';
+}
+
+export interface DomainFullResult extends VersionedFullBase {
+  type: 'domain';
+}
+
+export interface FlowFullResult extends VersionedFullBase {
+  type: 'flow';
+}
+
+export interface EntityFullResult extends VersionedFullBase {
+  type: 'entity';
+}
+
+export interface ChannelFullResult extends VersionedFullBase {
+  type: 'channel';
+}
+
+// Unversioned full result types
+
+export interface TeamFullResult extends UnversionedFullBase {
+  type: 'team';
+}
+
+export interface UserFullResult extends UnversionedFullBase {
+  type: 'user';
+}
+
+export interface DocFullResult extends UnversionedFullBase {
+  type: 'doc';
+}
+
+/**
+ * Union of all versioned full result types
+ */
+export type VersionedFullResult =
+  | EventFullResult
+  | CommandFullResult
+  | QueryFullResult
+  | ServiceFullResult
+  | DomainFullResult
+  | FlowFullResult
+  | EntityFullResult
+  | ChannelFullResult;
+
+/**
+ * Union of all unversioned full result types
+ */
+export type UnversionedFullResult = TeamFullResult | UserFullResult | DocFullResult;
+
+/**
+ * Union of all full result types (from .mdx files)
+ */
+export type FullResult = VersionedFullResult | UnversionedFullResult;
+
+// ============================================================================
+// Backwards Compatibility Aliases
+// ============================================================================
+
+/** @deprecated Use ListResult instead */
+export type ParsedResource = ListResult;
+
+/** @deprecated Use EventListResult instead */
+export type EventResource = EventListResult;
+
+/** @deprecated Use CommandListResult instead */
+export type CommandResource = CommandListResult;
+
+/** @deprecated Use QueryListResult instead */
+export type QueryResource = QueryListResult;
+
+/** @deprecated Use ServiceListResult instead */
+export type ServiceResource = ServiceListResult;
+
+/** @deprecated Use DomainListResult instead */
+export type DomainResource = DomainListResult;
+
+/** @deprecated Use FlowListResult instead */
+export type FlowResource = FlowListResult;
+
+/** @deprecated Use EntityListResult instead */
+export type EntityResource = EntityListResult;
+
+/** @deprecated Use ChannelListResult instead */
+export type ChannelResource = ChannelListResult;
+
+/** @deprecated Use TeamListResult instead */
+export type TeamResource = TeamListResult;
+
+/** @deprecated Use UserListResult instead */
+export type UserResource = UserListResult;
+
+/** @deprecated Use DocListResult instead */
+export type DocResource = DocListResult;
+
+// ============================================================================
+// Paginated Results
+// ============================================================================
+
+/**
+ * Paginated list response following MCP conventions
+ */
+export interface PaginatedListResult {
+  resources: ListResult[];
   nextCursor?: string;
+}
+
+/** @deprecated Use PaginatedListResult instead */
+export type PaginatedResult = PaginatedListResult;
+
+// ============================================================================
+// Owner Results (for find_owners tool)
+// ============================================================================
+
+/**
+ * Successful owner fetch result - either a user or team with full content
+ */
+export type OwnerResult = UserFullResult | TeamFullResult;
+
+/**
+ * Owner not found error
+ */
+export interface OwnerNotFoundError {
+  error: 'Owner not found';
+  message: string;
+  searchedUrls: string[];
+}
+
+// ============================================================================
+// Resource Not Found Error
+// ============================================================================
+
+/**
+ * Resource not found error
+ */
+export interface ResourceNotFoundError {
+  error: 'Resource not found';
+  message: string;
+  searchedUrl: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Base fields for versioned resources
+ */
+interface VersionedBase {
+  id: string;
+  name: string;
+  version: string;
+  summary?: string;
+  url: string;
+}
+
+/**
+ * Base fields for non-versioned resources
+ */
+interface UnversionedBase {
+  id: string;
+  name: string;
+  summary?: string;
+  url: string;
+}
+
+// Versioned resource types
+
+export interface EventResource extends VersionedBase {
+  type: 'event';
+}
+
+export interface CommandResource extends VersionedBase {
+  type: 'command';
+}
+
+export interface QueryResource extends VersionedBase {
+  type: 'query';
+}
+
+export interface ServiceResource extends VersionedBase {
+  type: 'service';
+}
+
+export interface DomainResource extends VersionedBase {
+  type: 'domain';
+}
+
+export interface FlowResource extends VersionedBase {
+  type: 'flow';
+}
+
+export interface EntityResource extends VersionedBase {
+  type: 'entity';
+}
+
+export interface ChannelResource extends VersionedBase {
+  type: 'channel';
+}
+
+// Non-versioned resource types
+
+export interface TeamResource extends UnversionedBase {
+  type: 'team';
+}
+
+export interface UserResource extends UnversionedBase {
+  type: 'user';
+}
+
+export interface DocResource extends UnversionedBase {
+  type: 'doc';
+}
+
+/**
+ * Union of all resource types
+ */
+export type ParsedResource =
+  | EventResource
+  | CommandResource
+  | QueryResource
+  | ServiceResource
+  | DomainResource
+  | FlowResource
+  | EntityResource
+  | ChannelResource
+  | TeamResource
+  | UserResource
+  | DocResource;
+
+/**
+ * Resource kind literals
+ */
+export type ResourceKind = ParsedResource['type'];
+
+/**
+ * Filter type including 'all'
+ */
+export type ResourceFilter = ResourceKind | 'all';
+
+/**
+ * Paginated response following MCP conventions
+ */
+export interface PaginatedResult {
+  resources: ParsedResource[];
+  nextCursor?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,14 +13,30 @@ export type VersionedKind = 'event' | 'command' | 'query' | 'service' | 'domain'
 export type UnversionedKind = 'team' | 'user' | 'doc';
 
 /**
- * All resource kinds
+ * All resource kinds (singular)
  */
 export type ResourceKind = VersionedKind | UnversionedKind;
 
 /**
- * Filter type including 'all'
+ * Plural resource kinds (for API params)
  */
-export type ResourceFilter = ResourceKind | 'all';
+export type PluralResourceKind =
+  | 'events'
+  | 'commands'
+  | 'queries'
+  | 'services'
+  | 'domains'
+  | 'flows'
+  | 'entities'
+  | 'channels'
+  | 'teams'
+  | 'users'
+  | 'docs';
+
+/**
+ * Filter type including 'all' (accepts both singular and plural)
+ */
+export type ResourceFilter = ResourceKind | PluralResourceKind | 'all';
 
 // ============================================================================
 // List Results (from llms.txt - summary info)

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -43,10 +43,7 @@ export function clearCache(): void {
  * Fetch owner (user or team) by id
  * Tries user first, then team
  */
-export async function fetchOwnerById(
-  ownerId: string,
-  fetchFn: typeof fetch = fetch
-): Promise<OwnerResult | OwnerNotFoundError> {
+export async function fetchOwnerById(ownerId: string, fetchFn: typeof fetch = fetch): Promise<OwnerResult | OwnerNotFoundError> {
   const baseUrl = getBaseUrl();
 
   // Try user first

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,7 +1,14 @@
 import { parseLlmsTxt } from '../parser.js';
-import type { ParsedResource } from '../types.js';
+import type { ParsedResource, OwnerResult, OwnerNotFoundError } from '../types.js';
 
 let cachedLlmsTxt: string | null = null;
+
+/**
+ * Get the base URL from environment
+ */
+export function getBaseUrl(): string {
+  return process.env.EVENTCATALOG_URL || '';
+}
 
 /**
  * Fetch llms.txt from EventCatalog and cache the result
@@ -9,7 +16,7 @@ let cachedLlmsTxt: string | null = null;
 export async function fetchLlmsTxt(): Promise<string> {
   if (cachedLlmsTxt) return cachedLlmsTxt;
 
-  const baseUrl = process.env.EVENTCATALOG_URL || '';
+  const baseUrl = getBaseUrl();
   const url = new URL('/docs/llm/llms.txt', baseUrl);
   const response = await fetch(url.toString());
   const text = await response.text();
@@ -30,4 +37,46 @@ export async function fetchParsedResources(): Promise<ParsedResource[]> {
  */
 export function clearCache(): void {
   cachedLlmsTxt = null;
+}
+
+/**
+ * Fetch owner (user or team) by id
+ * Tries user first, then team
+ */
+export async function fetchOwnerById(
+  ownerId: string,
+  fetchFn: typeof fetch = fetch
+): Promise<OwnerResult | OwnerNotFoundError> {
+  const baseUrl = getBaseUrl();
+
+  // Try user first
+  const userUrl = new URL(`/docs/users/${ownerId}.mdx`, baseUrl);
+  let response = await fetchFn(userUrl.toString());
+  let ownerType: 'user' | 'team' = 'user';
+
+  if (!response.ok) {
+    // Try team
+    const teamUrl = new URL(`/docs/teams/${ownerId}.mdx`, baseUrl);
+    response = await fetchFn(teamUrl.toString());
+    ownerType = 'team';
+  }
+
+  if (!response.ok) {
+    return {
+      error: 'Owner not found',
+      message: `No user or team found with id '${ownerId}'`,
+      searchedUrls: [`${baseUrl}/docs/users/${ownerId}`, `${baseUrl}/docs/teams/${ownerId}`],
+    };
+  }
+
+  const content = await response.text();
+
+  return {
+    type: ownerType,
+    id: ownerId,
+    name: ownerId,
+    content,
+    mimeType: 'text/markdown',
+    url: `${baseUrl}/docs/${ownerType}s/${ownerId}`,
+  };
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,33 @@
+import { parseLlmsTxt } from '../parser.js';
+import type { ParsedResource } from '../types.js';
+
+let cachedLlmsTxt: string | null = null;
+
+/**
+ * Fetch llms.txt from EventCatalog and cache the result
+ */
+export async function fetchLlmsTxt(): Promise<string> {
+  if (cachedLlmsTxt) return cachedLlmsTxt;
+
+  const baseUrl = process.env.EVENTCATALOG_URL || '';
+  const url = new URL('/docs/llm/llms.txt', baseUrl);
+  const response = await fetch(url.toString());
+  const text = await response.text();
+  cachedLlmsTxt = text;
+  return text;
+}
+
+/**
+ * Fetch and parse llms.txt into typed resources
+ */
+export async function fetchParsedResources(): Promise<ParsedResource[]> {
+  const text = await fetchLlmsTxt();
+  return parseLlmsTxt(text);
+}
+
+/**
+ * Clear the cache (useful for testing)
+ */
+export function clearCache(): void {
+  cachedLlmsTxt = null;
+}

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -20,10 +20,7 @@ export const pluralToSingular: Record<PluralResourceKind, ResourceKind> = {
 /**
  * Filter resources by type (accepts both singular and plural)
  */
-export function filterByType(
-  resources: ParsedResource[],
-  type: ResourceKind | PluralResourceKind | 'all'
-): ParsedResource[] {
+export function filterByType(resources: ParsedResource[], type: ResourceKind | PluralResourceKind | 'all'): ParsedResource[] {
   if (type === 'all') {
     return resources;
   }
@@ -36,10 +33,7 @@ export function filterByType(
  * Filter resources by search term (case-insensitive)
  * Searches in name, id, and summary
  */
-export function filterBySearch(
-  resources: ParsedResource[],
-  search: string
-): ParsedResource[] {
+export function filterBySearch(resources: ParsedResource[], search: string): ParsedResource[] {
   const searchLower = search.toLowerCase();
   return resources.filter(
     (r) =>

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,0 +1,31 @@
+import type { ParsedResource, ResourceKind } from '../types.js';
+
+/**
+ * Filter resources by type
+ */
+export function filterByType(
+  resources: ParsedResource[],
+  type: ResourceKind | 'all'
+): ParsedResource[] {
+  if (type === 'all') {
+    return resources;
+  }
+  return resources.filter((r) => r.type === type);
+}
+
+/**
+ * Filter resources by search term (case-insensitive)
+ * Searches in name, id, and summary
+ */
+export function filterBySearch(
+  resources: ParsedResource[],
+  search: string
+): ParsedResource[] {
+  const searchLower = search.toLowerCase();
+  return resources.filter(
+    (r) =>
+      r.name.toLowerCase().includes(searchLower) ||
+      r.id.toLowerCase().includes(searchLower) ||
+      (r.summary && r.summary.toLowerCase().includes(searchLower))
+  );
+}

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,16 +1,35 @@
-import type { ParsedResource, ResourceKind } from '../types.js';
+import type { ParsedResource, ResourceKind, PluralResourceKind } from '../types.js';
 
 /**
- * Filter resources by type
+ * Map plural type to singular for filtering
+ */
+export const pluralToSingular: Record<PluralResourceKind, ResourceKind> = {
+  events: 'event',
+  commands: 'command',
+  queries: 'query',
+  services: 'service',
+  domains: 'domain',
+  flows: 'flow',
+  entities: 'entity',
+  channels: 'channel',
+  teams: 'team',
+  users: 'user',
+  docs: 'doc',
+};
+
+/**
+ * Filter resources by type (accepts both singular and plural)
  */
 export function filterByType(
   resources: ParsedResource[],
-  type: ResourceKind | 'all'
+  type: ResourceKind | PluralResourceKind | 'all'
 ): ParsedResource[] {
   if (type === 'all') {
     return resources;
   }
-  return resources.filter((r) => r.type === type);
+  // Convert plural to singular if needed
+  const singularType = (pluralToSingular as Record<string, ResourceKind>)[type] || type;
+  return resources.filter((r) => r.type === singularType);
 }
 
 /**

--- a/tests/cursor.spec.ts
+++ b/tests/cursor.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeCursor,
+  decodeCursor,
+  decodeCursorOrThrow,
+  InvalidCursorError,
+  INVALID_CURSOR_ERROR_CODE,
+} from '../src/cursor.js';
+
+describe('cursor', () => {
+  describe('encodeCursor', () => {
+    it('encodes position 0', () => {
+      const cursor = encodeCursor(0);
+      expect(cursor).toBe('MA'); // base64url of "0"
+    });
+
+    it('encodes position 50', () => {
+      const cursor = encodeCursor(50);
+      expect(cursor).toBe('NTA'); // base64url of "50"
+    });
+
+    it('encodes position 100', () => {
+      const cursor = encodeCursor(100);
+      expect(cursor).toBe('MTAw'); // base64url of "100"
+    });
+
+    it('encodes large position', () => {
+      const cursor = encodeCursor(999999);
+      expect(cursor).toBe('OTk5OTk5'); // base64url of "999999"
+    });
+  });
+
+  describe('decodeCursor', () => {
+    it('decodes valid cursor for position 0', () => {
+      const position = decodeCursor('MA');
+      expect(position).toBe(0);
+    });
+
+    it('decodes valid cursor for position 50', () => {
+      const position = decodeCursor('NTA');
+      expect(position).toBe(50);
+    });
+
+    it('decodes valid cursor for position 100', () => {
+      const position = decodeCursor('MTAw');
+      expect(position).toBe(100);
+    });
+
+    it('decodes large position', () => {
+      const position = decodeCursor('OTk5OTk5');
+      expect(position).toBe(999999);
+    });
+
+    it('returns null for empty string', () => {
+      const position = decodeCursor('');
+      expect(position).toBeNull();
+    });
+
+    it('returns null for invalid base64', () => {
+      const position = decodeCursor('!!!invalid!!!');
+      expect(position).toBeNull();
+    });
+
+    it('returns null for non-numeric content', () => {
+      // base64url of "abc"
+      const position = decodeCursor('YWJj');
+      expect(position).toBeNull();
+    });
+
+    it('returns null for negative number', () => {
+      // base64url of "-1"
+      const position = decodeCursor('LTE');
+      expect(position).toBeNull();
+    });
+
+    it('returns null for float', () => {
+      // base64url of "1.5" - parseInt will return 1, which is valid
+      // Actually parseInt("1.5") returns 1, so this should pass
+      const position = decodeCursor('MS41');
+      expect(position).toBe(1); // parseInt truncates
+    });
+  });
+
+  describe('roundtrip', () => {
+    it('encode then decode returns original position', () => {
+      const positions = [0, 1, 10, 50, 100, 500, 1000, 99999];
+
+      for (const original of positions) {
+        const cursor = encodeCursor(original);
+        const decoded = decodeCursor(cursor);
+        expect(decoded).toBe(original);
+      }
+    });
+  });
+
+  describe('decodeCursorOrThrow', () => {
+    it('returns position for valid cursor', () => {
+      const cursor = encodeCursor(50);
+      const position = decodeCursorOrThrow(cursor);
+      expect(position).toBe(50);
+    });
+
+    it('throws InvalidCursorError for invalid cursor', () => {
+      expect(() => decodeCursorOrThrow('invalid')).toThrow(InvalidCursorError);
+    });
+
+    it('throws InvalidCursorError for empty string', () => {
+      expect(() => decodeCursorOrThrow('')).toThrow(InvalidCursorError);
+    });
+
+    it('thrown error has MCP error code -32602', () => {
+      try {
+        decodeCursorOrThrow('invalid');
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidCursorError);
+        expect((error as InvalidCursorError).code).toBe(INVALID_CURSOR_ERROR_CODE);
+        expect((error as InvalidCursorError).code).toBe(-32602);
+      }
+    });
+  });
+
+  describe('InvalidCursorError', () => {
+    it('has correct error code', () => {
+      const error = new InvalidCursorError();
+      expect(error.code).toBe(-32602);
+    });
+
+    it('has correct name', () => {
+      const error = new InvalidCursorError();
+      expect(error.name).toBe('InvalidCursorError');
+    });
+
+    it('has default message', () => {
+      const error = new InvalidCursorError();
+      expect(error.message).toBe('Invalid or malformed cursor');
+    });
+
+    it('accepts custom message', () => {
+      const error = new InvalidCursorError('Custom error message');
+      expect(error.message).toBe('Custom error message');
+    });
+  });
+
+  describe('INVALID_CURSOR_ERROR_CODE', () => {
+    it('equals MCP Invalid params error code', () => {
+      expect(INVALID_CURSOR_ERROR_CODE).toBe(-32602);
+    });
+  });
+});

--- a/tests/cursor.spec.ts
+++ b/tests/cursor.spec.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  encodeCursor,
-  decodeCursor,
-  decodeCursorOrThrow,
-  InvalidCursorError,
-  INVALID_CURSOR_ERROR_CODE,
-} from '../src/cursor.js';
+import { encodeCursor, decodeCursor, decodeCursorOrThrow, InvalidCursorError, INVALID_CURSOR_ERROR_CODE } from '../src/cursor.js';
 
 describe('cursor', () => {
   describe('encodeCursor', () => {

--- a/tests/fetch-owner.spec.ts
+++ b/tests/fetch-owner.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchOwnerById } from '../src/utils/fetch.js';
+
+describe('fetchOwnerById', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+  });
+
+  it('returns user when user endpoint responds successfully', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('# User Content\nThis is user data'),
+    });
+
+    const result = await fetchOwnerById('john-doe', mockFetch);
+
+    expect(result).toEqual({
+      type: 'user',
+      id: 'john-doe',
+      name: 'john-doe',
+      content: '# User Content\nThis is user data',
+      mimeType: 'text/markdown',
+      url: 'https://example.com/docs/users/john-doe',
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/docs/users/john-doe.mdx');
+  });
+
+  it('returns team when user endpoint fails but team succeeds', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false }) // user fails
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('# Team Content\nThis is team data'),
+      });
+
+    const result = await fetchOwnerById('platform-team', mockFetch);
+
+    expect(result).toEqual({
+      type: 'team',
+      id: 'platform-team',
+      name: 'platform-team',
+      content: '# Team Content\nThis is team data',
+      mimeType: 'text/markdown',
+      url: 'https://example.com/docs/teams/platform-team',
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(1, 'https://example.com/docs/users/platform-team.mdx');
+    expect(mockFetch).toHaveBeenNthCalledWith(2, 'https://example.com/docs/teams/platform-team.mdx');
+  });
+
+  it('returns error when both user and team endpoints fail', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false }) // user fails
+      .mockResolvedValueOnce({ ok: false }); // team fails
+
+    const result = await fetchOwnerById('nonexistent', mockFetch);
+
+    expect(result).toEqual({
+      error: 'Owner not found',
+      message: "No user or team found with id 'nonexistent'",
+      searchedUrls: ['https://example.com/docs/users/nonexistent', 'https://example.com/docs/teams/nonexistent'],
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('tries user first before team', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('user content'),
+    });
+
+    await fetchOwnerById('asmith', mockFetch);
+
+    // Should only call user endpoint since it succeeded
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/docs/users/asmith.mdx');
+  });
+});
+
+describe('fetchOwnerById result types', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+  });
+
+  it('successful result has type, id, name, content, mimeType, and url', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('content'),
+    });
+
+    const result = await fetchOwnerById('test', mockFetch);
+
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result).toHaveProperty('type');
+      expect(result).toHaveProperty('id');
+      expect(result).toHaveProperty('name');
+      expect(result).toHaveProperty('content');
+      expect(result).toHaveProperty('mimeType');
+      expect(result).toHaveProperty('url');
+      expect(result.mimeType).toBe('text/markdown');
+    }
+  });
+
+  it('error result has error, message, and searchedUrls', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: false }).mockResolvedValueOnce({ ok: false });
+
+    const result = await fetchOwnerById('test', mockFetch);
+
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result).toHaveProperty('error', 'Owner not found');
+      expect(result).toHaveProperty('message');
+      expect(result).toHaveProperty('searchedUrls');
+      expect(result.searchedUrls).toHaveLength(2);
+    }
+  });
+});

--- a/tests/filter.spec.ts
+++ b/tests/filter.spec.ts
@@ -4,13 +4,48 @@ import type { ParsedResource } from '../src/types.js';
 
 // Sample resources for testing
 const sampleResources: ParsedResource[] = [
-  { type: 'event', id: 'OrderCreated', name: 'Order Created', version: '1.0.0', url: '/events/OrderCreated/1.0.0', summary: 'When an order is created' },
-  { type: 'event', id: 'PaymentReceived', name: 'Payment Received', version: '2.0.0', url: '/events/PaymentReceived/2.0.0', summary: 'Payment completed successfully' },
-  { type: 'command', id: 'CreateOrder', name: 'Create Order', version: '1.0.0', url: '/commands/CreateOrder/1.0.0', summary: 'Create a new order' },
-  { type: 'service', id: 'OrderService', name: 'Order Service', version: '1.0.0', url: '/services/OrderService/1.0.0', summary: 'Handles order processing' },
+  {
+    type: 'event',
+    id: 'OrderCreated',
+    name: 'Order Created',
+    version: '1.0.0',
+    url: '/events/OrderCreated/1.0.0',
+    summary: 'When an order is created',
+  },
+  {
+    type: 'event',
+    id: 'PaymentReceived',
+    name: 'Payment Received',
+    version: '2.0.0',
+    url: '/events/PaymentReceived/2.0.0',
+    summary: 'Payment completed successfully',
+  },
+  {
+    type: 'command',
+    id: 'CreateOrder',
+    name: 'Create Order',
+    version: '1.0.0',
+    url: '/commands/CreateOrder/1.0.0',
+    summary: 'Create a new order',
+  },
+  {
+    type: 'service',
+    id: 'OrderService',
+    name: 'Order Service',
+    version: '1.0.0',
+    url: '/services/OrderService/1.0.0',
+    summary: 'Handles order processing',
+  },
   { type: 'team', id: 'platform-team', name: 'Platform Team', url: '/teams/platform-team', summary: 'Core platform engineers' },
   { type: 'user', id: 'john-doe', name: 'John Doe', url: '/users/john-doe', summary: 'Senior Developer' },
-  { type: 'domain', id: 'Orders', name: 'Orders Domain', version: '1.0.0', url: '/domains/Orders/1.0.0', summary: 'Order management bounded context' },
+  {
+    type: 'domain',
+    id: 'Orders',
+    name: 'Orders Domain',
+    version: '1.0.0',
+    url: '/domains/Orders/1.0.0',
+    summary: 'Order management bounded context',
+  },
 ];
 
 describe('filterBySearch', () => {
@@ -110,9 +145,7 @@ describe('filterBySearch', () => {
     });
 
     it('handles special characters in search', () => {
-      const resourcesWithSpecial: ParsedResource[] = [
-        { type: 'team', id: 'my-team', name: 'My Team', url: '/teams/my-team' },
-      ];
+      const resourcesWithSpecial: ParsedResource[] = [{ type: 'team', id: 'my-team', name: 'My Team', url: '/teams/my-team' }];
       const result = filterBySearch(resourcesWithSpecial, 'my-team');
       expect(result).toHaveLength(1);
     });

--- a/tests/filter.spec.ts
+++ b/tests/filter.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { filterByType, filterBySearch, pluralToSingular } from '../src/utils/filter.js';
+import type { ParsedResource } from '../src/types.js';
+
+// Sample resources for testing
+const sampleResources: ParsedResource[] = [
+  { type: 'event', id: 'OrderCreated', name: 'Order Created', version: '1.0.0', url: '/events/OrderCreated/1.0.0', summary: 'When an order is created' },
+  { type: 'event', id: 'PaymentReceived', name: 'Payment Received', version: '2.0.0', url: '/events/PaymentReceived/2.0.0', summary: 'Payment completed successfully' },
+  { type: 'command', id: 'CreateOrder', name: 'Create Order', version: '1.0.0', url: '/commands/CreateOrder/1.0.0', summary: 'Create a new order' },
+  { type: 'service', id: 'OrderService', name: 'Order Service', version: '1.0.0', url: '/services/OrderService/1.0.0', summary: 'Handles order processing' },
+  { type: 'team', id: 'platform-team', name: 'Platform Team', url: '/teams/platform-team', summary: 'Core platform engineers' },
+  { type: 'user', id: 'john-doe', name: 'John Doe', url: '/users/john-doe', summary: 'Senior Developer' },
+  { type: 'domain', id: 'Orders', name: 'Orders Domain', version: '1.0.0', url: '/domains/Orders/1.0.0', summary: 'Order management bounded context' },
+];
+
+describe('filterBySearch', () => {
+  describe('basic search', () => {
+    it('finds resources by name', () => {
+      const result = filterBySearch(sampleResources, 'Order');
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.every((r) => r.name.toLowerCase().includes('order'))).toBe(true);
+    });
+
+    it('finds resources by id', () => {
+      const result = filterBySearch(sampleResources, 'OrderCreated');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('OrderCreated');
+    });
+
+    it('finds resources by summary', () => {
+      const result = filterBySearch(sampleResources, 'successfully');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('PaymentReceived');
+    });
+
+    it('returns empty array when no matches', () => {
+      const result = filterBySearch(sampleResources, 'nonexistent-term');
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', () => {
+      const result = filterBySearch([], 'order');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('matches lowercase search against uppercase name', () => {
+      const result = filterBySearch(sampleResources, 'order');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('matches uppercase search against lowercase content', () => {
+      const result = filterBySearch(sampleResources, 'ORDER');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('matches mixed case search', () => {
+      const result = filterBySearch(sampleResources, 'OrDeR');
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('partial matching', () => {
+    it('finds partial matches in name', () => {
+      const result = filterBySearch(sampleResources, 'Plat');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('platform-team');
+    });
+
+    it('finds partial matches in id', () => {
+      const result = filterBySearch(sampleResources, 'john');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('john-doe');
+    });
+
+    it('finds partial matches in summary', () => {
+      const result = filterBySearch(sampleResources, 'bounded');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('Orders');
+    });
+  });
+
+  describe('multiple matches', () => {
+    it('returns all matching resources', () => {
+      const result = filterBySearch(sampleResources, 'order');
+      // Should match: OrderCreated, CreateOrder, OrderService, Orders Domain
+      expect(result.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('matches across different fields', () => {
+      // "platform" appears in both id and name of platform-team
+      const result = filterBySearch(sampleResources, 'platform');
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles resources without summary', () => {
+      const resourcesNoSummary: ParsedResource[] = [
+        { type: 'event', id: 'TestEvent', name: 'Test Event', version: '1.0.0', url: '/events/TestEvent/1.0.0' },
+      ];
+      const result = filterBySearch(resourcesNoSummary, 'Test');
+      expect(result).toHaveLength(1);
+    });
+
+    it('handles single character search', () => {
+      const result = filterBySearch(sampleResources, 'O');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles special characters in search', () => {
+      const resourcesWithSpecial: ParsedResource[] = [
+        { type: 'team', id: 'my-team', name: 'My Team', url: '/teams/my-team' },
+      ];
+      const result = filterBySearch(resourcesWithSpecial, 'my-team');
+      expect(result).toHaveLength(1);
+    });
+
+    it('trims whitespace is handled by caller (returns no match with spaces)', () => {
+      // The function itself doesn't trim, so this tests current behavior
+      const result = filterBySearch(sampleResources, '  order  ');
+      // Won't match because the spaces are included in search
+      expect(result).toHaveLength(0);
+    });
+  });
+});
+
+describe('filterByType with plural types', () => {
+  it('filters by plural type "events"', () => {
+    const result = filterByType(sampleResources, 'events');
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.type === 'event')).toBe(true);
+  });
+
+  it('filters by plural type "commands"', () => {
+    const result = filterByType(sampleResources, 'commands');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('command');
+  });
+
+  it('filters by plural type "services"', () => {
+    const result = filterByType(sampleResources, 'services');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('service');
+  });
+
+  it('filters by plural type "teams"', () => {
+    const result = filterByType(sampleResources, 'teams');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('team');
+  });
+
+  it('filters by plural type "users"', () => {
+    const result = filterByType(sampleResources, 'users');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('user');
+  });
+
+  it('filters by plural type "domains"', () => {
+    const result = filterByType(sampleResources, 'domains');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('domain');
+  });
+
+  it('still works with singular types', () => {
+    const result = filterByType(sampleResources, 'event');
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('pluralToSingular mapping', () => {
+  it('maps all versioned plural types', () => {
+    expect(pluralToSingular.events).toBe('event');
+    expect(pluralToSingular.commands).toBe('command');
+    expect(pluralToSingular.queries).toBe('query');
+    expect(pluralToSingular.services).toBe('service');
+    expect(pluralToSingular.domains).toBe('domain');
+    expect(pluralToSingular.flows).toBe('flow');
+    expect(pluralToSingular.entities).toBe('entity');
+    expect(pluralToSingular.channels).toBe('channel');
+  });
+
+  it('maps all unversioned plural types', () => {
+    expect(pluralToSingular.teams).toBe('team');
+    expect(pluralToSingular.users).toBe('user');
+    expect(pluralToSingular.docs).toBe('doc');
+  });
+
+  it('has exactly 11 mappings', () => {
+    expect(Object.keys(pluralToSingular)).toHaveLength(11);
+  });
+
+  it('all values are valid ResourceKind', () => {
+    const validKinds = ['event', 'command', 'query', 'service', 'domain', 'flow', 'entity', 'channel', 'team', 'user', 'doc'];
+    for (const value of Object.values(pluralToSingular)) {
+      expect(validKinds).toContain(value);
+    }
+  });
+});

--- a/tests/find-resource.spec.ts
+++ b/tests/find-resource.spec.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseLlmsTxt } from '../src/parser.js';
+import { pluralToSingular } from '../src/utils/filter.js';
+import type { ParsedResource } from '../src/types.js';
 
-// Mock node-fetch before importing the module
-vi.mock('node-fetch', () => ({
-  default: vi.fn(),
-}));
-
-describe('find_resource tool', () => {
+describe('find_resource tool definition', () => {
   beforeEach(() => {
     vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
     vi.resetModules();
@@ -15,122 +13,196 @@ describe('find_resource tool', () => {
     vi.unstubAllEnvs();
   });
 
-  describe('tool definition', () => {
-    it('has correct name', async () => {
-      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
-      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
-      expect(tool).toBeDefined();
-      expect(tool!.name).toBe('find_resource');
-    });
-
-    it('has id, version, and type params', async () => {
-      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
-      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
-      expect(tool!.paramsSchema).toBeDefined();
-      expect(tool!.paramsSchema!.id).toBeDefined();
-      expect(tool!.paramsSchema!.version).toBeDefined();
-      expect(tool!.paramsSchema!.type).toBeDefined();
-    });
-
-    it('version param is optional', async () => {
-      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
-      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
-      const versionSchema = tool!.paramsSchema!.version;
-
-      expect(versionSchema.safeParse(undefined).success).toBe(true);
-      expect(versionSchema.safeParse('1.0.0').success).toBe(true);
-    });
-
-    it('type param accepts all valid plural types', async () => {
-      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
-      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
-      const typeSchema = tool!.paramsSchema!.type;
-
-      const validTypes = [
-        'services',
-        'domains',
-        'events',
-        'commands',
-        'queries',
-        'flows',
-        'entities',
-        'channels',
-      ];
-
-      for (const t of validTypes) {
-        const result = typeSchema.safeParse(t);
-        expect(result.success, `type "${t}" should be valid`).toBe(true);
-      }
-    });
-
-    it('type param rejects invalid types', async () => {
-      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
-      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
-      const typeSchema = tool!.paramsSchema!.type;
-
-      expect(typeSchema.safeParse('invalid').success).toBe(false);
-      expect(typeSchema.safeParse('event').success).toBe(false); // singular not allowed
-      expect(typeSchema.safeParse('all').success).toBe(false);
-    });
-  });
-});
-
-describe('find_resource handler', () => {
-  beforeEach(() => {
-    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
-    vi.resetModules();
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.resetAllMocks();
-  });
-
-  it('fetches resource with provided version', async () => {
-    const fetch = (await import('node-fetch')).default as unknown as ReturnType<typeof vi.fn>;
-    fetch.mockResolvedValueOnce({
-      text: () => Promise.resolve('# Event Content\nThis is the event markdown'),
-    });
-
-    // Import handlers after mocking
+  it('has correct name', async () => {
     const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
     const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
-
-    // We can't easily test the handler directly, but we can verify the tool is configured correctly
     expect(tool).toBeDefined();
+    expect(tool!.name).toBe('find_resource');
   });
 
-  it('looks up version from llms.txt when not provided', async () => {
-    // This test verifies the logic flow - when version is not provided,
-    // it should look up from llms.txt
+  it('has id, version, and type params', async () => {
     const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
     const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+    expect(tool!.paramsSchema).toBeDefined();
+    expect(tool!.paramsSchema!.id).toBeDefined();
+    expect(tool!.paramsSchema!.version).toBeDefined();
+    expect(tool!.paramsSchema!.type).toBeDefined();
+  });
 
-    // Verify version is optional
+  it('version param is optional', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
     const versionSchema = tool!.paramsSchema!.version;
-    expect(versionSchema.isOptional()).toBe(true);
+
+    expect(versionSchema.safeParse(undefined).success).toBe(true);
+    expect(versionSchema.safeParse('1.0.0').success).toBe(true);
+  });
+
+  it('type param accepts all valid plural types', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+    const typeSchema = tool!.paramsSchema!.type;
+
+    const validTypes = ['services', 'domains', 'events', 'commands', 'queries', 'flows', 'entities', 'channels'];
+
+    for (const t of validTypes) {
+      const result = typeSchema.safeParse(t);
+      expect(result.success, `type "${t}" should be valid`).toBe(true);
+    }
+  });
+
+  it('type param rejects invalid types', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+    const typeSchema = tool!.paramsSchema!.type;
+
+    expect(typeSchema.safeParse('invalid').success).toBe(false);
+    expect(typeSchema.safeParse('event').success).toBe(false); // singular not allowed
+    expect(typeSchema.safeParse('all').success).toBe(false);
   });
 });
 
-describe('pluralToSingular mapping', () => {
-  it('maps all plural types to singular', async () => {
-    const { pluralToSingular } = await import('../src/utils/filter.js');
+describe('find_resource version lookup logic', () => {
+  // Sample llms.txt content for testing
+  const sampleLlmsTxt = `# Test EventCatalog
 
-    expect(pluralToSingular.events).toBe('event');
-    expect(pluralToSingular.commands).toBe('command');
-    expect(pluralToSingular.queries).toBe('query');
-    expect(pluralToSingular.services).toBe('service');
-    expect(pluralToSingular.domains).toBe('domain');
-    expect(pluralToSingular.flows).toBe('flow');
-    expect(pluralToSingular.entities).toBe('entity');
-    expect(pluralToSingular.channels).toBe('channel');
-    expect(pluralToSingular.teams).toBe('team');
-    expect(pluralToSingular.users).toBe('user');
-    expect(pluralToSingular.docs).toBe('doc');
+## Events
+- [Order Created - OrderCreated - 1.0.0](https://example.com/docs/events/OrderCreated/1.0.0.mdx) - Order created event
+- [Order Created - OrderCreated - 2.0.0](https://example.com/docs/events/OrderCreated/2.0.0.mdx) - Order created event v2
+- [Payment Received - PaymentReceived - 1.0.0](https://example.com/docs/events/PaymentReceived/1.0.0.mdx) - Payment received
+
+## Services
+- [Order Service - OrderService - 1.0.0](https://example.com/docs/services/OrderService/1.0.0.mdx) - Handles orders
+- [Payment Service - PaymentService - 2.5.0](https://example.com/docs/services/PaymentService/2.5.0.mdx) - Handles payments
+
+## Teams
+- [platform](https://example.com/docs/teams/platform.mdx) - Platform Team
+`;
+
+  let parsedResources: ParsedResource[];
+
+  beforeEach(() => {
+    parsedResources = parseLlmsTxt(sampleLlmsTxt);
   });
 
-  it('has all 11 mappings', async () => {
-    const { pluralToSingular } = await import('../src/utils/filter.js');
-    expect(Object.keys(pluralToSingular)).toHaveLength(11);
+  it('finds resource by id and type', () => {
+    const singularType = pluralToSingular['events'];
+    const resource = parsedResources.find((r) => r.id === 'OrderCreated' && r.type === singularType);
+
+    expect(resource).toBeDefined();
+    expect(resource!.id).toBe('OrderCreated');
+    expect(resource!.type).toBe('event');
+  });
+
+  it('returns first matching resource when multiple versions exist', () => {
+    const singularType = pluralToSingular['events'];
+    const resource = parsedResources.find((r) => r.id === 'OrderCreated' && r.type === singularType);
+
+    // First one in the list (1.0.0)
+    expect(resource).toBeDefined();
+    if (resource && 'version' in resource) {
+      expect(resource.version).toBe('1.0.0');
+    }
+  });
+
+  it('finds service by id', () => {
+    const singularType = pluralToSingular['services'];
+    const resource = parsedResources.find((r) => r.id === 'OrderService' && r.type === singularType);
+
+    expect(resource).toBeDefined();
+    expect(resource!.type).toBe('service');
+    if (resource && 'version' in resource) {
+      expect(resource.version).toBe('1.0.0');
+    }
+  });
+
+  it('returns undefined for non-existent resource', () => {
+    const singularType = pluralToSingular['events'];
+    const resource = parsedResources.find((r) => r.id === 'NonExistent' && r.type === singularType);
+
+    expect(resource).toBeUndefined();
+  });
+
+  it('returns undefined for wrong type', () => {
+    // OrderCreated is an event, not a service
+    const singularType = pluralToSingular['services'];
+    const resource = parsedResources.find((r) => r.id === 'OrderCreated' && r.type === singularType);
+
+    expect(resource).toBeUndefined();
+  });
+
+  it('teams do not have version', () => {
+    const singularType = pluralToSingular['teams'];
+    const resource = parsedResources.find((r) => r.id === 'platform' && r.type === singularType);
+
+    expect(resource).toBeDefined();
+    expect(resource!.type).toBe('team');
+    expect('version' in resource!).toBe(false);
+  });
+
+  it('pluralToSingular correctly maps all types', () => {
+    expect(pluralToSingular['events']).toBe('event');
+    expect(pluralToSingular['commands']).toBe('command');
+    expect(pluralToSingular['queries']).toBe('query');
+    expect(pluralToSingular['services']).toBe('service');
+    expect(pluralToSingular['domains']).toBe('domain');
+    expect(pluralToSingular['flows']).toBe('flow');
+    expect(pluralToSingular['entities']).toBe('entity');
+    expect(pluralToSingular['channels']).toBe('channel');
+    expect(pluralToSingular['teams']).toBe('team');
+    expect(pluralToSingular['users']).toBe('user');
+    expect(pluralToSingular['docs']).toBe('doc');
+  });
+});
+
+describe('get_schema tool definition', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('has correct name', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'get_schema');
+    expect(tool).toBeDefined();
+    expect(tool!.name).toBe('get_schema');
+  });
+
+  it('has id, version, and type params', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'get_schema');
+    expect(tool!.paramsSchema).toBeDefined();
+    expect(tool!.paramsSchema!.id).toBeDefined();
+    expect(tool!.paramsSchema!.version).toBeDefined();
+    expect(tool!.paramsSchema!.type).toBeDefined();
+  });
+
+  it('type param accepts all valid plural types', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'get_schema');
+    const typeSchema = tool!.paramsSchema!.type;
+
+    const validTypes = ['services', 'domains', 'events', 'commands', 'queries', 'flows', 'entities', 'channels'];
+
+    for (const t of validTypes) {
+      const result = typeSchema.safeParse(t);
+      expect(result.success, `type "${t}" should be valid`).toBe(true);
+    }
+  });
+
+  it('uses same types as find_resource', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const findResource = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+    const getSchema = TOOL_DEFINITIONS.find((t) => t.name === 'get_schema');
+
+    // Both should have the same type options
+    const findResourceTypes = findResource!.paramsSchema!.type._def.values;
+    const getSchemaTypes = getSchema!.paramsSchema!.type._def.values;
+
+    expect(findResourceTypes).toEqual(getSchemaTypes);
   });
 });

--- a/tests/find-resource.spec.ts
+++ b/tests/find-resource.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock node-fetch before importing the module
+vi.mock('node-fetch', () => ({
+  default: vi.fn(),
+}));
+
+describe('find_resource tool', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('tool definition', () => {
+    it('has correct name', async () => {
+      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+      expect(tool).toBeDefined();
+      expect(tool!.name).toBe('find_resource');
+    });
+
+    it('has id, version, and type params', async () => {
+      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+      expect(tool!.paramsSchema).toBeDefined();
+      expect(tool!.paramsSchema!.id).toBeDefined();
+      expect(tool!.paramsSchema!.version).toBeDefined();
+      expect(tool!.paramsSchema!.type).toBeDefined();
+    });
+
+    it('version param is optional', async () => {
+      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+      const versionSchema = tool!.paramsSchema!.version;
+
+      expect(versionSchema.safeParse(undefined).success).toBe(true);
+      expect(versionSchema.safeParse('1.0.0').success).toBe(true);
+    });
+
+    it('type param accepts all valid plural types', async () => {
+      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+      const typeSchema = tool!.paramsSchema!.type;
+
+      const validTypes = [
+        'services',
+        'domains',
+        'events',
+        'commands',
+        'queries',
+        'flows',
+        'entities',
+        'channels',
+      ];
+
+      for (const t of validTypes) {
+        const result = typeSchema.safeParse(t);
+        expect(result.success, `type "${t}" should be valid`).toBe(true);
+      }
+    });
+
+    it('type param rejects invalid types', async () => {
+      const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+      const typeSchema = tool!.paramsSchema!.type;
+
+      expect(typeSchema.safeParse('invalid').success).toBe(false);
+      expect(typeSchema.safeParse('event').success).toBe(false); // singular not allowed
+      expect(typeSchema.safeParse('all').success).toBe(false);
+    });
+  });
+});
+
+describe('find_resource handler', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetAllMocks();
+  });
+
+  it('fetches resource with provided version', async () => {
+    const fetch = (await import('node-fetch')).default as unknown as ReturnType<typeof vi.fn>;
+    fetch.mockResolvedValueOnce({
+      text: () => Promise.resolve('# Event Content\nThis is the event markdown'),
+    });
+
+    // Import handlers after mocking
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+
+    // We can't easily test the handler directly, but we can verify the tool is configured correctly
+    expect(tool).toBeDefined();
+  });
+
+  it('looks up version from llms.txt when not provided', async () => {
+    // This test verifies the logic flow - when version is not provided,
+    // it should look up from llms.txt
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resource');
+
+    // Verify version is optional
+    const versionSchema = tool!.paramsSchema!.version;
+    expect(versionSchema.isOptional()).toBe(true);
+  });
+});
+
+describe('pluralToSingular mapping', () => {
+  it('maps all plural types to singular', async () => {
+    const { pluralToSingular } = await import('../src/utils/filter.js');
+
+    expect(pluralToSingular.events).toBe('event');
+    expect(pluralToSingular.commands).toBe('command');
+    expect(pluralToSingular.queries).toBe('query');
+    expect(pluralToSingular.services).toBe('service');
+    expect(pluralToSingular.domains).toBe('domain');
+    expect(pluralToSingular.flows).toBe('flow');
+    expect(pluralToSingular.entities).toBe('entity');
+    expect(pluralToSingular.channels).toBe('channel');
+    expect(pluralToSingular.teams).toBe('team');
+    expect(pluralToSingular.users).toBe('user');
+    expect(pluralToSingular.docs).toBe('doc');
+  });
+
+  it('has all 11 mappings', async () => {
+    const { pluralToSingular } = await import('../src/utils/filter.js');
+    expect(Object.keys(pluralToSingular)).toHaveLength(11);
+  });
+});

--- a/tests/find-resources.spec.ts
+++ b/tests/find-resources.spec.ts
@@ -258,23 +258,23 @@ describe('find_resources tool definition', () => {
     expect(schema.cursor).toBeDefined();
   });
 
-  it('type param accepts all valid resource types', async () => {
+  it('type param accepts all valid resource types (plural)', async () => {
     const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
     const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
     const typeSchema = tool!.paramsSchema!.type;
 
     const validTypes = [
-      'event',
-      'command',
-      'query',
-      'service',
-      'domain',
-      'flow',
-      'entity',
-      'channel',
-      'team',
-      'user',
-      'doc',
+      'events',
+      'commands',
+      'queries',
+      'services',
+      'domains',
+      'flows',
+      'entities',
+      'channels',
+      'teams',
+      'users',
+      'docs',
       'all',
     ];
 

--- a/tests/find-resources.spec.ts
+++ b/tests/find-resources.spec.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect } from 'vitest';
+import { filterAndPaginateResources } from '../src/tools/index.js';
+import { encodeCursor, decodeCursor, InvalidCursorError } from '../src/cursor.js';
+import type { ParsedResource } from '../src/types.js';
+
+// Sample resources for testing
+const sampleResources: ParsedResource[] = [
+  { type: 'event', id: 'OrderCreated', name: 'Order Created', version: '1.0.0', url: '/events/OrderCreated/1.0.0', summary: 'When an order is created' },
+  { type: 'event', id: 'OrderShipped', name: 'Order Shipped', version: '1.0.0', url: '/events/OrderShipped/1.0.0', summary: 'When order ships' },
+  { type: 'event', id: 'PaymentReceived', name: 'Payment Received', version: '2.0.0', url: '/events/PaymentReceived/2.0.0', summary: 'Payment completed' },
+  { type: 'command', id: 'CreateOrder', name: 'Create Order', version: '1.0.0', url: '/commands/CreateOrder/1.0.0', summary: 'Create a new order' },
+  { type: 'command', id: 'ShipOrder', name: 'Ship Order', version: '1.0.0', url: '/commands/ShipOrder/1.0.0', summary: 'Ship an order' },
+  { type: 'service', id: 'OrderService', name: 'Order Service', version: '1.0.0', url: '/services/OrderService/1.0.0', summary: 'Handles orders' },
+  { type: 'service', id: 'PaymentService', name: 'Payment Service', version: '1.0.0', url: '/services/PaymentService/1.0.0', summary: 'Handles payments' },
+  { type: 'team', id: 'platform-team', name: 'Platform Team', url: '/teams/platform-team', summary: 'Core platform' },
+  { type: 'team', id: 'payments-team', name: 'Payments Team', url: '/teams/payments-team', summary: 'Payment processing' },
+  { type: 'user', id: 'john-doe', name: 'John Doe', url: '/users/john-doe', summary: 'Developer' },
+];
+
+describe('filterAndPaginateResources', () => {
+  describe('no filters', () => {
+    it('returns all resources when no params provided', () => {
+      const result = filterAndPaginateResources(sampleResources, {});
+      expect(result.resources).toEqual(sampleResources);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('returns all resources when type is "all"', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'all' });
+      expect(result.resources).toEqual(sampleResources);
+    });
+  });
+
+  describe('type filtering', () => {
+    it('filters by event type', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'event' });
+      expect(result.resources).toHaveLength(3);
+      expect(result.resources.every((r) => r.type === 'event')).toBe(true);
+    });
+
+    it('filters by command type', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'command' });
+      expect(result.resources).toHaveLength(2);
+      expect(result.resources.every((r) => r.type === 'command')).toBe(true);
+    });
+
+    it('filters by service type', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'service' });
+      expect(result.resources).toHaveLength(2);
+      expect(result.resources.every((r) => r.type === 'service')).toBe(true);
+    });
+
+    it('filters by team type', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'team' });
+      expect(result.resources).toHaveLength(2);
+      expect(result.resources.every((r) => r.type === 'team')).toBe(true);
+    });
+
+    it('filters by user type', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'user' });
+      expect(result.resources).toHaveLength(1);
+      expect(result.resources[0].id).toBe('john-doe');
+    });
+
+    it('returns empty array for type with no matches', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'flow' });
+      expect(result.resources).toHaveLength(0);
+    });
+  });
+
+  describe('search filtering', () => {
+    it('searches by name (case-insensitive)', () => {
+      const result = filterAndPaginateResources(sampleResources, { search: 'order' });
+      // Should match: OrderCreated, OrderShipped, CreateOrder, ShipOrder, OrderService
+      expect(result.resources).toHaveLength(5);
+    });
+
+    it('searches by id', () => {
+      const result = filterAndPaginateResources(sampleResources, { search: 'PaymentService' });
+      expect(result.resources).toHaveLength(1);
+      expect(result.resources[0].id).toBe('PaymentService');
+    });
+
+    it('searches by summary', () => {
+      const result = filterAndPaginateResources(sampleResources, { search: 'completed' });
+      expect(result.resources).toHaveLength(1);
+      expect(result.resources[0].id).toBe('PaymentReceived');
+    });
+
+    it('search is case-insensitive', () => {
+      const result = filterAndPaginateResources(sampleResources, { search: 'ORDER' });
+      expect(result.resources).toHaveLength(5);
+    });
+
+    it('returns empty array for search with no matches', () => {
+      const result = filterAndPaginateResources(sampleResources, { search: 'nonexistent' });
+      expect(result.resources).toHaveLength(0);
+    });
+  });
+
+  describe('combined filtering', () => {
+    it('filters by type AND search', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'event', search: 'order' });
+      // Should match: OrderCreated, OrderShipped (events containing "order")
+      expect(result.resources).toHaveLength(2);
+      expect(result.resources.every((r) => r.type === 'event')).toBe(true);
+    });
+
+    it('type and search combination with no results', () => {
+      const result = filterAndPaginateResources(sampleResources, { type: 'team', search: 'order' });
+      expect(result.resources).toHaveLength(0);
+    });
+  });
+
+  describe('pagination', () => {
+    // Create 100 resources for pagination testing
+    const manyResources: ParsedResource[] = Array.from({ length: 100 }, (_, i) => ({
+      type: 'event' as const,
+      id: `Event${i}`,
+      name: `Event ${i}`,
+      version: '1.0.0',
+      url: `/events/Event${i}/1.0.0`,
+      summary: `Event number ${i}`,
+    }));
+
+    it('returns first page (50 items) without cursor', () => {
+      const result = filterAndPaginateResources(manyResources, {});
+      expect(result.resources).toHaveLength(50);
+      expect(result.resources[0].id).toBe('Event0');
+      expect(result.resources[49].id).toBe('Event49');
+      expect(result.nextCursor).toBeDefined();
+    });
+
+    it('returns second page with cursor', () => {
+      const cursor = encodeCursor(50);
+      const result = filterAndPaginateResources(manyResources, { cursor });
+      expect(result.resources).toHaveLength(50);
+      expect(result.resources[0].id).toBe('Event50');
+      expect(result.resources[49].id).toBe('Event99');
+      expect(result.nextCursor).toBeUndefined(); // No more pages
+    });
+
+    it('nextCursor is absent when no more items', () => {
+      // Small set that fits in one page
+      const result = filterAndPaginateResources(sampleResources, {});
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('nextCursor is present when more items exist', () => {
+      const result = filterAndPaginateResources(manyResources, {});
+      expect(result.nextCursor).toBeDefined();
+      const decodedPosition = decodeCursor(result.nextCursor!);
+      expect(decodedPosition).toBe(50);
+    });
+
+    it('throws InvalidCursorError for invalid cursor', () => {
+      expect(() => filterAndPaginateResources(sampleResources, { cursor: 'invalid!!!' }))
+        .toThrow(InvalidCursorError);
+    });
+
+    it('InvalidCursorError has MCP error code -32602', () => {
+      try {
+        filterAndPaginateResources(sampleResources, { cursor: 'invalid!!!' });
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidCursorError);
+        expect((error as InvalidCursorError).code).toBe(-32602);
+      }
+    });
+
+    it('returns empty array for cursor beyond data range', () => {
+      const cursor = encodeCursor(1000); // Way beyond our 10 items
+      const result = filterAndPaginateResources(sampleResources, { cursor });
+      expect(result.resources).toHaveLength(0);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('pagination works correctly with filtering', () => {
+      // Create 75 events and 25 commands
+      const mixedResources: ParsedResource[] = [
+        ...Array.from({ length: 75 }, (_, i) => ({
+          type: 'event' as const,
+          id: `Event${i}`,
+          name: `Event ${i}`,
+          version: '1.0.0',
+          url: `/events/Event${i}/1.0.0`,
+        })),
+        ...Array.from({ length: 25 }, (_, i) => ({
+          type: 'command' as const,
+          id: `Command${i}`,
+          name: `Command ${i}`,
+          version: '1.0.0',
+          url: `/commands/Command${i}/1.0.0`,
+        })),
+      ];
+
+      // Filter by event (75 items) - should give first page with nextCursor
+      const result1 = filterAndPaginateResources(mixedResources, { type: 'event' });
+      expect(result1.resources).toHaveLength(50);
+      expect(result1.nextCursor).toBeDefined();
+
+      // Filter by command (25 items) - should fit in one page
+      const result2 = filterAndPaginateResources(mixedResources, { type: 'command' });
+      expect(result2.resources).toHaveLength(25);
+      expect(result2.nextCursor).toBeUndefined();
+    });
+  });
+
+  describe('cursor pagination roundtrip', () => {
+    const manyResources: ParsedResource[] = Array.from({ length: 120 }, (_, i) => ({
+      type: 'event' as const,
+      id: `Event${i}`,
+      name: `Event ${i}`,
+      version: '1.0.0',
+      url: `/events/Event${i}/1.0.0`,
+    }));
+
+    it('can iterate through all pages', () => {
+      const allCollected: ParsedResource[] = [];
+      let cursor: string | undefined = undefined;
+
+      // Page 1
+      const result1 = filterAndPaginateResources(manyResources, { cursor });
+      allCollected.push(...result1.resources);
+      cursor = result1.nextCursor;
+      expect(cursor).toBeDefined();
+
+      // Page 2
+      const result2 = filterAndPaginateResources(manyResources, { cursor });
+      allCollected.push(...result2.resources);
+      cursor = result2.nextCursor;
+      expect(cursor).toBeDefined();
+
+      // Page 3 (last)
+      const result3 = filterAndPaginateResources(manyResources, { cursor });
+      allCollected.push(...result3.resources);
+      cursor = result3.nextCursor;
+      expect(cursor).toBeUndefined(); // No more pages
+
+      expect(allCollected).toHaveLength(120);
+      expect(allCollected[0].id).toBe('Event0');
+      expect(allCollected[119].id).toBe('Event119');
+    });
+  });
+});
+
+describe('find_resources tool definition', () => {
+  it('has paramsSchema with type, search, and cursor', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
+
+    expect(tool).toBeDefined();
+    expect(tool!.paramsSchema).toBeDefined();
+
+    const schema = tool!.paramsSchema!;
+    expect(schema.type).toBeDefined();
+    expect(schema.search).toBeDefined();
+    expect(schema.cursor).toBeDefined();
+  });
+
+  it('type param accepts all valid resource types', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
+    const typeSchema = tool!.paramsSchema!.type;
+
+    const validTypes = [
+      'event',
+      'command',
+      'query',
+      'service',
+      'domain',
+      'flow',
+      'entity',
+      'channel',
+      'team',
+      'user',
+      'doc',
+      'all',
+    ];
+
+    for (const t of validTypes) {
+      const result = typeSchema.safeParse(t);
+      expect(result.success, `type "${t}" should be valid`).toBe(true);
+    }
+  });
+
+  it('type param rejects invalid types', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
+    const typeSchema = tool!.paramsSchema!.type;
+
+    const result = typeSchema.safeParse('invalid');
+    expect(result.success).toBe(false);
+  });
+
+  it('type param defaults to "all"', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
+    const typeSchema = tool!.paramsSchema!.type;
+
+    const result = typeSchema.parse(undefined);
+    expect(result).toBe('all');
+  });
+
+  it('search param is optional string with trimming', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
+    const searchSchema = tool!.paramsSchema!.search;
+
+    expect(searchSchema.safeParse(undefined).success).toBe(true);
+    expect(searchSchema.safeParse('order').success).toBe(true);
+    expect(searchSchema.parse('  trimmed  ')).toBe('trimmed');
+  });
+
+  it('cursor param is optional string', async () => {
+    const { TOOL_DEFINITIONS } = await import('../src/tools/index.js');
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'find_resources');
+    const cursorSchema = tool!.paramsSchema!.cursor;
+
+    expect(cursorSchema.safeParse(undefined).success).toBe(true);
+    expect(cursorSchema.safeParse('abc123').success).toBe(true);
+  });
+});

--- a/tests/find-resources.spec.ts
+++ b/tests/find-resources.spec.ts
@@ -5,13 +5,62 @@ import type { ParsedResource } from '../src/types.js';
 
 // Sample resources for testing
 const sampleResources: ParsedResource[] = [
-  { type: 'event', id: 'OrderCreated', name: 'Order Created', version: '1.0.0', url: '/events/OrderCreated/1.0.0', summary: 'When an order is created' },
-  { type: 'event', id: 'OrderShipped', name: 'Order Shipped', version: '1.0.0', url: '/events/OrderShipped/1.0.0', summary: 'When order ships' },
-  { type: 'event', id: 'PaymentReceived', name: 'Payment Received', version: '2.0.0', url: '/events/PaymentReceived/2.0.0', summary: 'Payment completed' },
-  { type: 'command', id: 'CreateOrder', name: 'Create Order', version: '1.0.0', url: '/commands/CreateOrder/1.0.0', summary: 'Create a new order' },
-  { type: 'command', id: 'ShipOrder', name: 'Ship Order', version: '1.0.0', url: '/commands/ShipOrder/1.0.0', summary: 'Ship an order' },
-  { type: 'service', id: 'OrderService', name: 'Order Service', version: '1.0.0', url: '/services/OrderService/1.0.0', summary: 'Handles orders' },
-  { type: 'service', id: 'PaymentService', name: 'Payment Service', version: '1.0.0', url: '/services/PaymentService/1.0.0', summary: 'Handles payments' },
+  {
+    type: 'event',
+    id: 'OrderCreated',
+    name: 'Order Created',
+    version: '1.0.0',
+    url: '/events/OrderCreated/1.0.0',
+    summary: 'When an order is created',
+  },
+  {
+    type: 'event',
+    id: 'OrderShipped',
+    name: 'Order Shipped',
+    version: '1.0.0',
+    url: '/events/OrderShipped/1.0.0',
+    summary: 'When order ships',
+  },
+  {
+    type: 'event',
+    id: 'PaymentReceived',
+    name: 'Payment Received',
+    version: '2.0.0',
+    url: '/events/PaymentReceived/2.0.0',
+    summary: 'Payment completed',
+  },
+  {
+    type: 'command',
+    id: 'CreateOrder',
+    name: 'Create Order',
+    version: '1.0.0',
+    url: '/commands/CreateOrder/1.0.0',
+    summary: 'Create a new order',
+  },
+  {
+    type: 'command',
+    id: 'ShipOrder',
+    name: 'Ship Order',
+    version: '1.0.0',
+    url: '/commands/ShipOrder/1.0.0',
+    summary: 'Ship an order',
+  },
+  {
+    type: 'service',
+    id: 'OrderService',
+    name: 'Order Service',
+    version: '1.0.0',
+    url: '/services/OrderService/1.0.0',
+    summary: 'Handles orders',
+  },
+  {
+    type: 'service',
+    id: 'PaymentService',
+    name: 'Payment Service',
+    version: '1.0.0',
+    url: '/services/PaymentService/1.0.0',
+    summary: 'Handles payments',
+  },
   { type: 'team', id: 'platform-team', name: 'Platform Team', url: '/teams/platform-team', summary: 'Core platform' },
   { type: 'team', id: 'payments-team', name: 'Payments Team', url: '/teams/payments-team', summary: 'Payment processing' },
   { type: 'user', id: 'john-doe', name: 'John Doe', url: '/users/john-doe', summary: 'Developer' },
@@ -154,8 +203,7 @@ describe('filterAndPaginateResources', () => {
     });
 
     it('throws InvalidCursorError for invalid cursor', () => {
-      expect(() => filterAndPaginateResources(sampleResources, { cursor: 'invalid!!!' }))
-        .toThrow(InvalidCursorError);
+      expect(() => filterAndPaginateResources(sampleResources, { cursor: 'invalid!!!' })).toThrow(InvalidCursorError);
     });
 
     it('InvalidCursorError has MCP error code -32602', () => {

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { parseLlmsTxt } from '../src/parser.js';
+import { filterByType, filterBySearch } from '../src/utils/filter.js';
+import { encodeCursor, decodeCursor } from '../src/cursor.js';
+import type { ParsedResource } from '../src/types.js';
+
+/**
+ * Integration tests using real data from demo.eventcatalog.dev
+ * These tests verify the full pipeline works with production-like data
+ */
+
+const DEMO_LLMS_TXT_URL = 'https://demo.eventcatalog.dev/docs/llm/llms.txt';
+
+describe('Integration tests with demo.eventcatalog.dev', () => {
+  let llmsTxt: string;
+  let parsedResources: ParsedResource[];
+
+  beforeAll(async () => {
+    // Fetch real llms.txt from demo EventCatalog
+    const response = await fetch(DEMO_LLMS_TXT_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch llms.txt: ${response.status}`);
+    }
+    llmsTxt = await response.text();
+    parsedResources = parseLlmsTxt(llmsTxt);
+  });
+
+  describe('parser with real data', () => {
+    it('parses llms.txt successfully', () => {
+      expect(parsedResources.length).toBeGreaterThan(0);
+    });
+
+    it('parses events', () => {
+      const events = parsedResources.filter((r) => r.type === 'event');
+      expect(events.length).toBeGreaterThan(0);
+      // All events should have version
+      for (const event of events) {
+        expect(event).toHaveProperty('version');
+        expect(event.version).toMatch(/^\d+\.\d+\.\d+$/);
+      }
+    });
+
+    it('parses services', () => {
+      const services = parsedResources.filter((r) => r.type === 'service');
+      expect(services.length).toBeGreaterThan(0);
+      // All services should have id, name, version, url
+      for (const service of services) {
+        expect(service.id).toBeTruthy();
+        expect(service.name).toBeTruthy();
+        expect(service).toHaveProperty('version');
+        expect(service.url).toBeTruthy();
+      }
+    });
+
+    it('parses domains', () => {
+      const domains = parsedResources.filter((r) => r.type === 'domain');
+      expect(domains.length).toBeGreaterThan(0);
+    });
+
+    it('parses commands', () => {
+      const commands = parsedResources.filter((r) => r.type === 'command');
+      expect(commands.length).toBeGreaterThan(0);
+    });
+
+    it('parses queries', () => {
+      const queries = parsedResources.filter((r) => r.type === 'query');
+      expect(queries.length).toBeGreaterThan(0);
+    });
+
+    it('parses teams', () => {
+      const teams = parsedResources.filter((r) => r.type === 'team');
+      expect(teams.length).toBeGreaterThan(0);
+      // Teams should NOT have version
+      for (const team of teams) {
+        expect(team).not.toHaveProperty('version');
+      }
+    });
+
+    it('parses users', () => {
+      const users = parsedResources.filter((r) => r.type === 'user');
+      expect(users.length).toBeGreaterThan(0);
+    });
+
+    it('all resources have required fields', () => {
+      for (const resource of parsedResources) {
+        expect(resource.id).toBeTruthy();
+        expect(resource.name).toBeTruthy();
+        expect(resource.type).toBeTruthy();
+        expect(resource.url).toBeTruthy();
+      }
+    });
+  });
+
+  describe('filtering with real data', () => {
+    it('filters by plural type "events"', () => {
+      const events = filterByType(parsedResources, 'events');
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every((r) => r.type === 'event')).toBe(true);
+    });
+
+    it('filters by plural type "services"', () => {
+      const services = filterByType(parsedResources, 'services');
+      expect(services.length).toBeGreaterThan(0);
+      expect(services.every((r) => r.type === 'service')).toBe(true);
+    });
+
+    it('filters by "all" returns everything', () => {
+      const all = filterByType(parsedResources, 'all');
+      expect(all).toHaveLength(parsedResources.length);
+    });
+
+    it('search finds resources by name', () => {
+      // Search for a common term that should exist
+      const results = filterBySearch(parsedResources, 'Order');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('search is case-insensitive', () => {
+      const lowercase = filterBySearch(parsedResources, 'order');
+      const uppercase = filterBySearch(parsedResources, 'ORDER');
+      expect(lowercase).toEqual(uppercase);
+    });
+
+    it('combined type + search filtering', () => {
+      const events = filterByType(parsedResources, 'events');
+      const orderEvents = filterBySearch(events, 'Order');
+
+      // All results should be events containing "order"
+      for (const event of orderEvents) {
+        expect(event.type).toBe('event');
+        const hasOrder =
+          event.name.toLowerCase().includes('order') ||
+          event.id.toLowerCase().includes('order') ||
+          (event.summary && event.summary.toLowerCase().includes('order'));
+        expect(hasOrder).toBe(true);
+      }
+    });
+  });
+
+  describe('pagination with real data', () => {
+    it('paginate through all resources', () => {
+      const pageSize = 50;
+      const allCollected: ParsedResource[] = [];
+      let position = 0;
+
+      while (position < parsedResources.length) {
+        const page = parsedResources.slice(position, position + pageSize);
+        allCollected.push(...page);
+        position += pageSize;
+      }
+
+      expect(allCollected).toHaveLength(parsedResources.length);
+    });
+
+    it('cursor encoding/decoding works for pagination', () => {
+      const positions = [0, 50, 100, 150];
+
+      for (const pos of positions) {
+        const cursor = encodeCursor(pos);
+        const decoded = decodeCursor(cursor);
+        expect(decoded).toBe(pos);
+      }
+    });
+
+    it('simulate paginated API response', () => {
+      const pageSize = 50;
+      let cursor: string | undefined = undefined;
+      let position = 0;
+      const pages: ParsedResource[][] = [];
+
+      // Simulate fetching pages
+      while (position < parsedResources.length) {
+        const page = parsedResources.slice(position, position + pageSize);
+        pages.push(page);
+
+        position += pageSize;
+        if (position < parsedResources.length) {
+          cursor = encodeCursor(position);
+        } else {
+          cursor = undefined;
+        }
+      }
+
+      // Verify we got all resources across pages
+      const totalFromPages = pages.reduce((sum, page) => sum + page.length, 0);
+      expect(totalFromPages).toBe(parsedResources.length);
+
+      // Last page should have no cursor (or cursor leads to empty)
+      if (cursor) {
+        const lastPosition = decodeCursor(cursor);
+        expect(lastPosition).toBeGreaterThanOrEqual(parsedResources.length);
+      }
+    });
+  });
+
+  describe('version lookup simulation', () => {
+    it('can find latest version of a resource by id', () => {
+      const events = filterByType(parsedResources, 'events');
+      if (events.length > 0) {
+        const firstEvent = events[0];
+
+        // Simulate looking up version by id
+        const found = parsedResources.find(
+          (r) => r.id === firstEvent.id && r.type === 'event'
+        );
+
+        expect(found).toBeDefined();
+        expect(found).toHaveProperty('version');
+      }
+    });
+
+    it('can find resource by id and type', () => {
+      const services = filterByType(parsedResources, 'services');
+      if (services.length > 0) {
+        const service = services[0];
+
+        // Simulate the find_resource lookup
+        const found = parsedResources.find(
+          (r) => r.id === service.id && r.type === 'service'
+        );
+
+        expect(found).toBeDefined();
+        expect(found?.id).toBe(service.id);
+        expect(found?.type).toBe('service');
+      }
+    });
+  });
+
+  describe('URL format validation', () => {
+    it('all URLs are valid format', () => {
+      for (const resource of parsedResources) {
+        expect(resource.url).toMatch(/^https?:\/\//);
+        expect(resource.url).toContain('.mdx');
+      }
+    });
+
+    it('versioned resources have version in URL path', () => {
+      const versioned = parsedResources.filter((r) => 'version' in r);
+      // At least some versioned resources should have version in URL
+      // (some resources may have different naming schemes)
+      const withVersionInUrl = versioned.filter((r) => {
+        if ('version' in r) {
+          return r.url.includes(r.version);
+        }
+        return false;
+      });
+      expect(withVersionInUrl.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('data integrity', () => {
+    it('resources have unique URLs', () => {
+      // URLs should be unique identifiers
+      const urls = parsedResources.map((r) => r.url);
+      const uniqueUrls = new Set(urls);
+      expect(uniqueUrls.size).toBe(urls.length);
+    });
+
+    it('resource types are valid', () => {
+      const validTypes = ['event', 'command', 'query', 'service', 'domain', 'flow', 'entity', 'channel', 'team', 'user', 'doc'];
+      for (const resource of parsedResources) {
+        expect(validTypes).toContain(resource.type);
+      }
+    });
+  });
+});

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -200,9 +200,7 @@ describe('Integration tests with demo.eventcatalog.dev', () => {
         const firstEvent = events[0];
 
         // Simulate looking up version by id
-        const found = parsedResources.find(
-          (r) => r.id === firstEvent.id && r.type === 'event'
-        );
+        const found = parsedResources.find((r) => r.id === firstEvent.id && r.type === 'event');
 
         expect(found).toBeDefined();
         expect(found).toHaveProperty('version');
@@ -215,9 +213,7 @@ describe('Integration tests with demo.eventcatalog.dev', () => {
         const service = services[0];
 
         // Simulate the find_resource lookup
-        const found = parsedResources.find(
-          (r) => r.id === service.id && r.type === 'service'
-        );
+        const found = parsedResources.find((r) => r.id === service.id && r.type === 'service');
 
         expect(found).toBeDefined();
         expect(found?.id).toBe(service.id);

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect } from 'vitest';
+import { parseLlmsTxt } from '../src/parser.js';
+
+describe('parseLlmsTxt', () => {
+  describe('versioned resources', () => {
+    it('parses events section', () => {
+      const input = `## Events
+- [Order Placed - OrderPlaced - 1.0.0](https://example.com/docs/events/OrderPlaced/1.0.0.mdx) - Event triggered when order is placed`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'event',
+        id: 'OrderPlaced',
+        name: 'Order Placed',
+        version: '1.0.0',
+        summary: 'Event triggered when order is placed',
+        url: 'https://example.com/docs/events/OrderPlaced/1.0.0.mdx',
+      });
+    });
+
+    it('parses commands section', () => {
+      const input = `## Commands
+- [Process Payment - ProcessPayment - 0.0.1](https://example.com/docs/commands/ProcessPayment/0.0.1.mdx) - Command to process payment`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'command',
+        id: 'ProcessPayment',
+        name: 'Process Payment',
+        version: '0.0.1',
+        summary: 'Command to process payment',
+        url: 'https://example.com/docs/commands/ProcessPayment/0.0.1.mdx',
+      });
+    });
+
+    it('parses queries section', () => {
+      const input = `## Queries
+- [Get Order - GetOrder - 1.0.0](https://example.com/docs/queries/GetOrder/1.0.0.mdx) - Query to get order details`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'query',
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '1.0.0',
+        summary: 'Query to get order details',
+        url: 'https://example.com/docs/queries/GetOrder/1.0.0.mdx',
+      });
+    });
+
+    it('parses services section', () => {
+      const input = `## Services
+- [Payment Service - PaymentService - 1.0.0](https://example.com/docs/services/PaymentService/1.0.0.mdx) - Handles payments`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'service',
+        id: 'PaymentService',
+        name: 'Payment Service',
+        version: '1.0.0',
+        summary: 'Handles payments',
+        url: 'https://example.com/docs/services/PaymentService/1.0.0.mdx',
+      });
+    });
+
+    it('parses domains section', () => {
+      const input = `## Domains
+- [Payment Domain - Payment - 1.0.0](https://example.com/docs/domains/Payment/1.0.0.mdx) - Payment bounded context`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'domain',
+        id: 'Payment',
+        name: 'Payment Domain',
+        version: '1.0.0',
+        summary: 'Payment bounded context',
+        url: 'https://example.com/docs/domains/Payment/1.0.0.mdx',
+      });
+    });
+
+    it('parses flows section', () => {
+      const input = `## Flows
+- [Payment Flow - PaymentFlow - 1.0.0](https://example.com/docs/flows/PaymentFlow/1.0.0.mdx) - Payment process flow`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'flow',
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '1.0.0',
+        summary: 'Payment process flow',
+        url: 'https://example.com/docs/flows/PaymentFlow/1.0.0.mdx',
+      });
+    });
+
+    it('parses entities section', () => {
+      const input = `## Entities
+- [Order Entity - Order - 1.0.0](https://example.com/docs/entities/Order/1.0.0.mdx) - Order aggregate root`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'entity',
+        id: 'Order',
+        name: 'Order Entity',
+        version: '1.0.0',
+        summary: 'Order aggregate root',
+        url: 'https://example.com/docs/entities/Order/1.0.0.mdx',
+      });
+    });
+
+    it('parses channels section', () => {
+      const input = `## Channels
+- [Orders Channel - orders.events - 1.0.0](https://example.com/docs/channels/orders.events/1.0.0.mdx) - Kafka topic for orders`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'channel',
+        id: 'orders.events',
+        name: 'Orders Channel',
+        version: '1.0.0',
+        summary: 'Kafka topic for orders',
+        url: 'https://example.com/docs/channels/orders.events/1.0.0.mdx',
+      });
+    });
+
+    it('handles resource without summary', () => {
+      const input = `## Events
+- [Order Placed - OrderPlaced - 1.0.0](https://example.com/docs/events/OrderPlaced/1.0.0.mdx)`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'event',
+        id: 'OrderPlaced',
+        name: 'Order Placed',
+        version: '1.0.0',
+        summary: undefined,
+        url: 'https://example.com/docs/events/OrderPlaced/1.0.0.mdx',
+      });
+    });
+
+    it('handles name with hyphens', () => {
+      const input = `## Events
+- [Order Re-Placed - OrderRePlaced - 1.0.0](https://example.com/docs/events/OrderRePlaced/1.0.0.mdx) - Re-placed order`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'event',
+        id: 'OrderRePlaced',
+        name: 'Order Re-Placed',
+        version: '1.0.0',
+        summary: 'Re-placed order',
+        url: 'https://example.com/docs/events/OrderRePlaced/1.0.0.mdx',
+      });
+    });
+  });
+
+  describe('non-versioned resources', () => {
+    it('parses teams section', () => {
+      const input = `## Teams
+- [full-stack](https://example.com/docs/teams/full-stack.mdx) - Full Stack Team`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'team',
+        id: 'full-stack',
+        name: 'Full Stack Team',
+        url: 'https://example.com/docs/teams/full-stack.mdx',
+      });
+    });
+
+    it('parses users section', () => {
+      const input = `## Users
+- [jdoe](https://example.com/docs/users/jdoe.mdx) - John Doe`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'user',
+        id: 'jdoe',
+        name: 'John Doe',
+        url: 'https://example.com/docs/users/jdoe.mdx',
+      });
+    });
+
+    it('parses custom docs section', () => {
+      const input = `## Custom Docs
+- [Getting Started](https://example.com/docs/pages/getting-started.mdx) - Introduction guide`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'doc',
+        id: 'Getting Started',
+        name: 'Introduction guide',
+        url: 'https://example.com/docs/pages/getting-started.mdx',
+      });
+    });
+
+    it('uses id as name when no description provided', () => {
+      const input = `## Teams
+- [backend-team](https://example.com/docs/teams/backend-team.mdx)`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        type: 'team',
+        id: 'backend-team',
+        name: 'backend-team',
+        url: 'https://example.com/docs/teams/backend-team.mdx',
+      });
+    });
+  });
+
+  describe('multiple sections', () => {
+    it('parses multiple sections correctly', () => {
+      const input = `## Events
+- [Order Placed - OrderPlaced - 1.0.0](https://example.com/docs/events/OrderPlaced/1.0.0.mdx) - Order placed
+
+## Services
+- [Order Service - OrderService - 1.0.0](https://example.com/docs/services/OrderService/1.0.0.mdx) - Manages orders
+
+## Teams
+- [platform](https://example.com/docs/teams/platform.mdx) - Platform Team`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].type).toBe('event');
+      expect(result[1].type).toBe('service');
+      expect(result[2].type).toBe('team');
+    });
+
+    it('parses multiple resources in same section', () => {
+      const input = `## Events
+- [Order Placed - OrderPlaced - 1.0.0](https://example.com/docs/events/OrderPlaced/1.0.0.mdx) - Order placed
+- [Order Shipped - OrderShipped - 1.0.0](https://example.com/docs/events/OrderShipped/1.0.0.mdx) - Order shipped
+- [Order Delivered - OrderDelivered - 1.0.0](https://example.com/docs/events/OrderDelivered/1.0.0.mdx) - Order delivered`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(3);
+      expect(result.map(r => r.id)).toEqual(['OrderPlaced', 'OrderShipped', 'OrderDelivered']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      const result = parseLlmsTxt('');
+      expect(result).toEqual([]);
+    });
+
+    it('ignores unknown sections', () => {
+      const input = `## Unknown Section
+- [Something - Something - 1.0.0](https://example.com/something.mdx) - Unknown`;
+
+      const result = parseLlmsTxt(input);
+      expect(result).toEqual([]);
+    });
+
+    it('ignores malformed lines', () => {
+      const input = `## Events
+- This is not a valid line
+- [Order Placed - OrderPlaced - 1.0.0](https://example.com/docs/events/OrderPlaced/1.0.0.mdx) - Valid
+- Another invalid line`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('OrderPlaced');
+    });
+
+    it('ignores lines before first section', () => {
+      const input = `# Some Header
+Some text here
+- [Invalid - Invalid - 1.0.0](https://example.com/invalid.mdx) - Should be ignored
+
+## Events
+- [Order Placed - OrderPlaced - 1.0.0](https://example.com/docs/events/OrderPlaced/1.0.0.mdx) - Valid`;
+
+      const result = parseLlmsTxt(input);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('OrderPlaced');
+    });
+
+    it('skips versioned resource with less than 3 parts', () => {
+      const input = `## Events
+- [Only Two Parts - 1.0.0](https://example.com/invalid.mdx) - Invalid format`;
+
+      const result = parseLlmsTxt(input);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('realistic full catalog', () => {
+    it('parses a complete llms.txt file with all sections', () => {
+      const input = `# FlowMart EventCatalog
+
+> Documentation for FlowMart's event-driven architecture
+
+## Events
+- [Order Placed - OrderPlaced - 1.0.0](https://demo.eventcatalog.dev/docs/events/OrderPlaced/1.0.0.mdx) - Triggered when a customer places an order
+- [Order Confirmed - OrderConfirmed - 1.0.0](https://demo.eventcatalog.dev/docs/events/OrderConfirmed/1.0.0.mdx) - Triggered when an order is confirmed by the system
+- [Payment Processed - PaymentProcessed - 2.0.0](https://demo.eventcatalog.dev/docs/events/PaymentProcessed/2.0.0.mdx) - Triggered when payment is successfully processed
+- [Payment Failed - PaymentFailed - 1.0.0](https://demo.eventcatalog.dev/docs/events/PaymentFailed/1.0.0.mdx) - Triggered when payment processing fails
+- [Inventory Updated - InventoryUpdated - 1.0.0](https://demo.eventcatalog.dev/docs/events/InventoryUpdated/1.0.0.mdx) - Triggered when inventory levels change
+- [Shipment Created - ShipmentCreated - 1.0.0](https://demo.eventcatalog.dev/docs/events/ShipmentCreated/1.0.0.mdx) - Triggered when a shipment is created
+
+## Commands
+- [Place Order - PlaceOrder - 1.0.0](https://demo.eventcatalog.dev/docs/commands/PlaceOrder/1.0.0.mdx) - Command to place a new order
+- [Process Payment - ProcessPayment - 1.0.0](https://demo.eventcatalog.dev/docs/commands/ProcessPayment/1.0.0.mdx) - Command to process a payment
+- [Update Inventory - UpdateInventory - 1.0.0](https://demo.eventcatalog.dev/docs/commands/UpdateInventory/1.0.0.mdx) - Command to update inventory levels
+- [Create Shipment - CreateShipment - 1.0.0](https://demo.eventcatalog.dev/docs/commands/CreateShipment/1.0.0.mdx) - Command to create a new shipment
+
+## Queries
+- [Get Order - GetOrder - 1.0.0](https://demo.eventcatalog.dev/docs/queries/GetOrder/1.0.0.mdx) - Query to retrieve order details
+- [Get Inventory - GetInventory - 1.0.0](https://demo.eventcatalog.dev/docs/queries/GetInventory/1.0.0.mdx) - Query to check inventory levels
+- [Get Customer - GetCustomer - 1.0.0](https://demo.eventcatalog.dev/docs/queries/GetCustomer/1.0.0.mdx) - Query to retrieve customer information
+
+## Services
+- [Order Service - OrderService - 1.0.0](https://demo.eventcatalog.dev/docs/services/OrderService/1.0.0.mdx) - Manages order lifecycle
+- [Payment Service - PaymentService - 2.0.0](https://demo.eventcatalog.dev/docs/services/PaymentService/2.0.0.mdx) - Handles payment processing
+- [Inventory Service - InventoryService - 1.0.0](https://demo.eventcatalog.dev/docs/services/InventoryService/1.0.0.mdx) - Manages product inventory
+- [Shipping Service - ShippingService - 1.0.0](https://demo.eventcatalog.dev/docs/services/ShippingService/1.0.0.mdx) - Handles shipping and delivery
+- [Notification Service - NotificationService - 1.0.0](https://demo.eventcatalog.dev/docs/services/NotificationService/1.0.0.mdx) - Sends notifications to customers
+
+## Domains
+- [Order Management - OrderManagement - 1.0.0](https://demo.eventcatalog.dev/docs/domains/OrderManagement/1.0.0.mdx) - Order management bounded context
+- [Payment - Payment - 1.0.0](https://demo.eventcatalog.dev/docs/domains/Payment/1.0.0.mdx) - Payment processing bounded context
+- [Fulfillment - Fulfillment - 1.0.0](https://demo.eventcatalog.dev/docs/domains/Fulfillment/1.0.0.mdx) - Order fulfillment bounded context
+
+## Flows
+- [Order to Delivery - OrderToDelivery - 1.0.0](https://demo.eventcatalog.dev/docs/flows/OrderToDelivery/1.0.0.mdx) - Complete flow from order placement to delivery
+- [Payment Processing - PaymentProcessing - 1.0.0](https://demo.eventcatalog.dev/docs/flows/PaymentProcessing/1.0.0.mdx) - Payment processing workflow
+
+## Entities
+- [Order - Order - 1.0.0](https://demo.eventcatalog.dev/docs/entities/Order/1.0.0.mdx) - Order aggregate root
+- [Customer - Customer - 1.0.0](https://demo.eventcatalog.dev/docs/entities/Customer/1.0.0.mdx) - Customer entity
+- [Product - Product - 1.0.0](https://demo.eventcatalog.dev/docs/entities/Product/1.0.0.mdx) - Product entity
+
+## Channels
+- [orders.events - orders.events - 1.0.0](https://demo.eventcatalog.dev/docs/channels/orders.events/1.0.0.mdx) - Kafka topic for order events
+- [payments.events - payments.events - 1.0.0](https://demo.eventcatalog.dev/docs/channels/payments.events/1.0.0.mdx) - Kafka topic for payment events
+
+## Teams
+- [platform](https://demo.eventcatalog.dev/docs/teams/platform.mdx) - Platform Engineering Team
+- [orders](https://demo.eventcatalog.dev/docs/teams/orders.mdx) - Orders Team
+- [payments](https://demo.eventcatalog.dev/docs/teams/payments.mdx) - Payments Team
+- [fulfillment](https://demo.eventcatalog.dev/docs/teams/fulfillment.mdx) - Fulfillment Team
+
+## Users
+- [jdoe](https://demo.eventcatalog.dev/docs/users/jdoe.mdx) - John Doe
+- [asmith](https://demo.eventcatalog.dev/docs/users/asmith.mdx) - Alice Smith
+- [bjohnson](https://demo.eventcatalog.dev/docs/users/bjohnson.mdx) - Bob Johnson
+
+## Custom Docs
+- [Getting Started](https://demo.eventcatalog.dev/docs/pages/getting-started.mdx) - Introduction to FlowMart architecture
+- [Architecture Overview](https://demo.eventcatalog.dev/docs/pages/architecture.mdx) - High-level architecture documentation
+- [API Guidelines](https://demo.eventcatalog.dev/docs/pages/api-guidelines.mdx) - API design guidelines`;
+
+      const result = parseLlmsTxt(input);
+
+      // Count by type
+      const events = result.filter(r => r.type === 'event');
+      const commands = result.filter(r => r.type === 'command');
+      const queries = result.filter(r => r.type === 'query');
+      const services = result.filter(r => r.type === 'service');
+      const domains = result.filter(r => r.type === 'domain');
+      const flows = result.filter(r => r.type === 'flow');
+      const entities = result.filter(r => r.type === 'entity');
+      const channels = result.filter(r => r.type === 'channel');
+      const teams = result.filter(r => r.type === 'team');
+      const users = result.filter(r => r.type === 'user');
+      const docs = result.filter(r => r.type === 'doc');
+
+      // Verify counts
+      expect(events).toHaveLength(6);
+      expect(commands).toHaveLength(4);
+      expect(queries).toHaveLength(3);
+      expect(services).toHaveLength(5);
+      expect(domains).toHaveLength(3);
+      expect(flows).toHaveLength(2);
+      expect(entities).toHaveLength(3);
+      expect(channels).toHaveLength(2);
+      expect(teams).toHaveLength(4);
+      expect(users).toHaveLength(3);
+      expect(docs).toHaveLength(3);
+
+      // Total resources
+      expect(result).toHaveLength(38);
+
+      // Verify specific resources
+      expect(events[0]).toEqual({
+        type: 'event',
+        id: 'OrderPlaced',
+        name: 'Order Placed',
+        version: '1.0.0',
+        summary: 'Triggered when a customer places an order',
+        url: 'https://demo.eventcatalog.dev/docs/events/OrderPlaced/1.0.0.mdx',
+      });
+
+      expect(services[1]).toEqual({
+        type: 'service',
+        id: 'PaymentService',
+        name: 'Payment Service',
+        version: '2.0.0',
+        summary: 'Handles payment processing',
+        url: 'https://demo.eventcatalog.dev/docs/services/PaymentService/2.0.0.mdx',
+      });
+
+      expect(teams[0]).toEqual({
+        type: 'team',
+        id: 'platform',
+        name: 'Platform Engineering Team',
+        url: 'https://demo.eventcatalog.dev/docs/teams/platform.mdx',
+      });
+
+      expect(users[1]).toEqual({
+        type: 'user',
+        id: 'asmith',
+        name: 'Alice Smith',
+        url: 'https://demo.eventcatalog.dev/docs/users/asmith.mdx',
+      });
+
+      expect(docs[2]).toEqual({
+        type: 'doc',
+        id: 'API Guidelines',
+        name: 'API design guidelines',
+        url: 'https://demo.eventcatalog.dev/docs/pages/api-guidelines.mdx',
+      });
+    });
+  });
+});

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -264,7 +264,7 @@ describe('parseLlmsTxt', () => {
       const result = parseLlmsTxt(input);
 
       expect(result).toHaveLength(3);
-      expect(result.map(r => r.id)).toEqual(['OrderPlaced', 'OrderShipped', 'OrderDelivered']);
+      expect(result.map((r) => r.id)).toEqual(['OrderPlaced', 'OrderShipped', 'OrderDelivered']);
     });
   });
 
@@ -386,17 +386,17 @@ Some text here
       const result = parseLlmsTxt(input);
 
       // Count by type
-      const events = result.filter(r => r.type === 'event');
-      const commands = result.filter(r => r.type === 'command');
-      const queries = result.filter(r => r.type === 'query');
-      const services = result.filter(r => r.type === 'service');
-      const domains = result.filter(r => r.type === 'domain');
-      const flows = result.filter(r => r.type === 'flow');
-      const entities = result.filter(r => r.type === 'entity');
-      const channels = result.filter(r => r.type === 'channel');
-      const teams = result.filter(r => r.type === 'team');
-      const users = result.filter(r => r.type === 'user');
-      const docs = result.filter(r => r.type === 'doc');
+      const events = result.filter((r) => r.type === 'event');
+      const commands = result.filter((r) => r.type === 'command');
+      const queries = result.filter((r) => r.type === 'query');
+      const services = result.filter((r) => r.type === 'service');
+      const domains = result.filter((r) => r.type === 'domain');
+      const flows = result.filter((r) => r.type === 'flow');
+      const entities = result.filter((r) => r.type === 'entity');
+      const channels = result.filter((r) => r.type === 'channel');
+      const teams = result.filter((r) => r.type === 'team');
+      const users = result.filter((r) => r.type === 'user');
+      const docs = result.filter((r) => r.type === 'doc');
 
       // Verify counts
       expect(events).toHaveLength(6);

--- a/tests/resources.spec.ts
+++ b/tests/resources.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { filterByType } from '../src/utils/filter.js';
+import { parseLlmsTxt } from '../src/parser.js';
+import type { ParsedResource } from '../src/types.js';
+
+// Sample resources for testing
+const sampleResources: ParsedResource[] = [
+  { type: 'event', id: 'OrderCreated', name: 'Order Created', version: '1.0.0', url: '/events/OrderCreated/1.0.0', summary: 'When an order is created' },
+  { type: 'event', id: 'PaymentReceived', name: 'Payment Received', version: '2.0.0', url: '/events/PaymentReceived/2.0.0', summary: 'Payment completed' },
+  { type: 'command', id: 'CreateOrder', name: 'Create Order', version: '1.0.0', url: '/commands/CreateOrder/1.0.0', summary: 'Create a new order' },
+  { type: 'service', id: 'OrderService', name: 'Order Service', version: '1.0.0', url: '/services/OrderService/1.0.0', summary: 'Handles orders' },
+  { type: 'team', id: 'platform-team', name: 'Platform Team', url: '/teams/platform-team', summary: 'Core platform' },
+  { type: 'user', id: 'john-doe', name: 'John Doe', url: '/users/john-doe', summary: 'Developer' },
+];
+
+describe('filterByType', () => {
+  it('returns all resources when type is "all"', () => {
+    const result = filterByType(sampleResources, 'all');
+    expect(result).toEqual(sampleResources);
+    expect(result).toHaveLength(6);
+  });
+
+  it('filters by event type', () => {
+    const result = filterByType(sampleResources, 'event');
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.type === 'event')).toBe(true);
+    expect(result[0].id).toBe('OrderCreated');
+    expect(result[1].id).toBe('PaymentReceived');
+  });
+
+  it('filters by command type', () => {
+    const result = filterByType(sampleResources, 'command');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('command');
+    expect(result[0].id).toBe('CreateOrder');
+  });
+
+  it('filters by service type', () => {
+    const result = filterByType(sampleResources, 'service');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('service');
+    expect(result[0].id).toBe('OrderService');
+  });
+
+  it('filters by team type', () => {
+    const result = filterByType(sampleResources, 'team');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('team');
+    expect(result[0].id).toBe('platform-team');
+  });
+
+  it('filters by user type', () => {
+    const result = filterByType(sampleResources, 'user');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('user');
+    expect(result[0].id).toBe('john-doe');
+  });
+
+  it('returns empty array for type with no matches', () => {
+    const result = filterByType(sampleResources, 'flow');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when input is empty', () => {
+    const result = filterByType([], 'event');
+    expect(result).toHaveLength(0);
+  });
+
+  it('filters by query type', () => {
+    const resourcesWithQuery: ParsedResource[] = [
+      ...sampleResources,
+      { type: 'query', id: 'GetOrder', name: 'Get Order', version: '1.0.0', url: '/queries/GetOrder/1.0.0' },
+    ];
+    const result = filterByType(resourcesWithQuery, 'query');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('GetOrder');
+  });
+
+  it('filters by domain type', () => {
+    const resourcesWithDomain: ParsedResource[] = [
+      ...sampleResources,
+      { type: 'domain', id: 'Orders', name: 'Orders Domain', version: '1.0.0', url: '/domains/Orders/1.0.0' },
+    ];
+    const result = filterByType(resourcesWithDomain, 'domain');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('Orders');
+  });
+
+  it('filters by flow type', () => {
+    const resourcesWithFlow: ParsedResource[] = [
+      ...sampleResources,
+      { type: 'flow', id: 'OrderFlow', name: 'Order Flow', version: '1.0.0', url: '/flows/OrderFlow/1.0.0' },
+    ];
+    const result = filterByType(resourcesWithFlow, 'flow');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('OrderFlow');
+  });
+
+  it('preserves all resource fields', () => {
+    const result = filterByType(sampleResources, 'event');
+    const event = result[0];
+
+    expect(event).toHaveProperty('type', 'event');
+    expect(event).toHaveProperty('id', 'OrderCreated');
+    expect(event).toHaveProperty('name', 'Order Created');
+    expect(event).toHaveProperty('version', '1.0.0');
+    expect(event).toHaveProperty('url');
+    expect(event).toHaveProperty('summary', 'When an order is created');
+  });
+});
+
+describe('filterByType with parsed llms.txt', () => {
+  const mockLlmsTxt = `# EventCatalog
+
+## Events
+- [Order Created - OrderCreated - 1.0.0](https://example.com/docs/events/OrderCreated/1.0.0) - When an order is created
+- [Payment Received - PaymentReceived - 2.0.0](https://example.com/docs/events/PaymentReceived/2.0.0) - Payment completed
+
+## Commands
+- [Create Order - CreateOrder - 1.0.0](https://example.com/docs/commands/CreateOrder/1.0.0) - Create a new order
+
+## Services
+- [Order Service - OrderService - 1.0.0](https://example.com/docs/services/OrderService/1.0.0) - Handles orders
+
+## Teams
+- [Platform Team - platform-team](https://example.com/docs/teams/platform-team) - Core platform
+`;
+
+  it('works with parsed llms.txt data', () => {
+    const resources = parseLlmsTxt(mockLlmsTxt);
+
+    const events = filterByType(resources, 'event');
+    expect(events).toHaveLength(2);
+
+    const commands = filterByType(resources, 'command');
+    expect(commands).toHaveLength(1);
+
+    const services = filterByType(resources, 'service');
+    expect(services).toHaveLength(1);
+
+    const teams = filterByType(resources, 'team');
+    expect(teams).toHaveLength(1);
+
+    const all = filterByType(resources, 'all');
+    expect(all).toHaveLength(5);
+  });
+});

--- a/tests/resources.spec.ts
+++ b/tests/resources.spec.ts
@@ -31,10 +31,38 @@ const mockLlmsTxtForGetResources = `# Test EventCatalog
 
 // Sample resources for testing
 const sampleResources: ParsedResource[] = [
-  { type: 'event', id: 'OrderCreated', name: 'Order Created', version: '1.0.0', url: '/events/OrderCreated/1.0.0', summary: 'When an order is created' },
-  { type: 'event', id: 'PaymentReceived', name: 'Payment Received', version: '2.0.0', url: '/events/PaymentReceived/2.0.0', summary: 'Payment completed' },
-  { type: 'command', id: 'CreateOrder', name: 'Create Order', version: '1.0.0', url: '/commands/CreateOrder/1.0.0', summary: 'Create a new order' },
-  { type: 'service', id: 'OrderService', name: 'Order Service', version: '1.0.0', url: '/services/OrderService/1.0.0', summary: 'Handles orders' },
+  {
+    type: 'event',
+    id: 'OrderCreated',
+    name: 'Order Created',
+    version: '1.0.0',
+    url: '/events/OrderCreated/1.0.0',
+    summary: 'When an order is created',
+  },
+  {
+    type: 'event',
+    id: 'PaymentReceived',
+    name: 'Payment Received',
+    version: '2.0.0',
+    url: '/events/PaymentReceived/2.0.0',
+    summary: 'Payment completed',
+  },
+  {
+    type: 'command',
+    id: 'CreateOrder',
+    name: 'Create Order',
+    version: '1.0.0',
+    url: '/commands/CreateOrder/1.0.0',
+    summary: 'Create a new order',
+  },
+  {
+    type: 'service',
+    id: 'OrderService',
+    name: 'Order Service',
+    version: '1.0.0',
+    url: '/services/OrderService/1.0.0',
+    summary: 'Handles orders',
+  },
   { type: 'team', id: 'platform-team', name: 'Platform Team', url: '/teams/platform-team', summary: 'Core platform' },
   { type: 'user', id: 'john-doe', name: 'John Doe', url: '/users/john-doe', summary: 'Developer' },
 ];

--- a/tests/resources.spec.ts
+++ b/tests/resources.spec.ts
@@ -1,7 +1,33 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { filterByType } from '../src/utils/filter.js';
 import { parseLlmsTxt } from '../src/parser.js';
 import type { ParsedResource } from '../src/types.js';
+
+// Mock data for getResourcesByType tests
+const mockLlmsTxtForGetResources = `# Test EventCatalog
+
+## Events
+- [Order Created - OrderCreated - 1.0.0](https://example.com/docs/events/OrderCreated/1.0.0.mdx) - Order created event
+- [Payment Received - PaymentReceived - 2.0.0](https://example.com/docs/events/PaymentReceived/2.0.0.mdx) - Payment received
+
+## Services
+- [Order Service - OrderService - 1.0.0](https://example.com/docs/services/OrderService/1.0.0.mdx) - Handles orders
+
+## Domains
+- [Orders Domain - OrdersDomain - 1.0.0](https://example.com/docs/domains/OrdersDomain/1.0.0.mdx) - Order management
+
+## Commands
+- [Create Order - CreateOrder - 1.0.0](https://example.com/docs/commands/CreateOrder/1.0.0.mdx) - Create a new order
+
+## Queries
+- [Get Order - GetOrder - 1.0.0](https://example.com/docs/queries/GetOrder/1.0.0.mdx) - Retrieve an order
+
+## Teams
+- [platform](https://example.com/docs/teams/platform.mdx) - Platform Team
+
+## Users
+- [john-doe](https://example.com/docs/users/john-doe.mdx) - John Doe
+`;
 
 // Sample resources for testing
 const sampleResources: ParsedResource[] = [
@@ -143,5 +169,185 @@ describe('filterByType with parsed llms.txt', () => {
 
     const all = filterByType(resources, 'all');
     expect(all).toHaveLength(5);
+  });
+});
+
+describe('getResourcesByType', () => {
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+    vi.resetModules();
+
+    // Mock fetchParsedResources
+    vi.doMock('../src/utils/fetch.js', () => ({
+      fetchParsedResources: vi.fn(async () => parseLlmsTxt(mockLlmsTxtForGetResources)),
+      fetchLlmsTxt: vi.fn(async () => mockLlmsTxtForGetResources),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.doUnmock('../src/utils/fetch.js');
+  });
+
+  it('returns all resources when type is "all"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('all');
+    const parsed = JSON.parse(result);
+
+    expect(parsed).toHaveProperty('resources');
+    expect(Array.isArray(parsed.resources)).toBe(true);
+    expect(parsed.resources.length).toBe(8); // 2 events + 1 service + 1 domain + 1 command + 1 query + 1 team + 1 user
+  });
+
+  it('returns only events when type is "event"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('event');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(2);
+    expect(parsed.resources.every((r: any) => r.type === 'event')).toBe(true);
+  });
+
+  it('returns only services when type is "service"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('service');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.resources[0].type).toBe('service');
+    expect(parsed.resources[0].id).toBe('OrderService');
+  });
+
+  it('returns only domains when type is "domain"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('domain');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.resources[0].type).toBe('domain');
+  });
+
+  it('returns only commands when type is "command"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('command');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.resources[0].type).toBe('command');
+  });
+
+  it('returns only queries when type is "query"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('query');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.resources[0].type).toBe('query');
+  });
+
+  it('returns only teams when type is "team"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('team');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.resources[0].type).toBe('team');
+    expect(parsed.resources[0]).not.toHaveProperty('version');
+  });
+
+  it('returns only users when type is "user"', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('user');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(1);
+    expect(parsed.resources[0].type).toBe('user');
+    expect(parsed.resources[0]).not.toHaveProperty('version');
+  });
+
+  it('returns empty array for type with no resources', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('flow');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.resources).toHaveLength(0);
+  });
+
+  it('returns valid JSON with resources wrapper', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('event');
+
+    // Should be valid JSON
+    expect(() => JSON.parse(result)).not.toThrow();
+
+    // Should have resources property
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveProperty('resources');
+  });
+
+  it('resources have all required fields', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('event');
+    const parsed = JSON.parse(result);
+
+    for (const resource of parsed.resources) {
+      expect(resource).toHaveProperty('id');
+      expect(resource).toHaveProperty('name');
+      expect(resource).toHaveProperty('type');
+      expect(resource).toHaveProperty('url');
+      expect(resource).toHaveProperty('version'); // events are versioned
+    }
+  });
+
+  it('matches find_resources tool output format', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+    const result = await getResourcesByType('all');
+    const parsed = JSON.parse(result);
+
+    // Should match { resources: [...] } format used by find_resources tool
+    expect(parsed).toHaveProperty('resources');
+    expect(Array.isArray(parsed.resources)).toBe(true);
+    expect(Object.keys(parsed)).toEqual(['resources']);
+  });
+});
+
+describe('uriToType mapping (via resource definitions)', () => {
+  // uriToType is a private function, but we can verify its behavior
+  // through the resource definitions and their URIs
+
+  beforeEach(() => {
+    vi.stubEnv('EVENTCATALOG_URL', 'https://example.com');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('handles all standard resource types', async () => {
+    const { getResourcesByType } = await import('../src/resources/index.js');
+
+    // Test all singular types that uriToType should handle
+    const types = [
+      'all',
+      'event',
+      'domain',
+      'service',
+      'query',
+      'command',
+      'flow',
+      'team',
+      'user',
+      'entity',
+      'channel',
+      'doc',
+    ] as const;
+
+    for (const type of types) {
+      const result = await getResourcesByType(type);
+      expect(() => JSON.parse(result)).not.toThrow();
+      const parsed = JSON.parse(result);
+      expect(parsed).toHaveProperty('resources');
+    }
   });
 });


### PR DESCRIPTION
 # PR Summary

 ## Motivation

Improve the MCP server's type safety, consistency, and test coverage. The existing implementation lacked proper typing, had inconsistent API responses between tools and MCP resources, and had minimal test coverage.

## What's Added
  - Type system (src/types.ts): Comprehensive types including ParsedResource, ResourceKind, PluralResourceKind, ListResult/FullResult hierarchies
  - Parser (src/parser.ts): Parses llms.txt format into typed resources
  - Cursor-based pagination (src/cursor.ts): 50 items per page with base64-encoded cursors
  - Filter utilities (src/utils/filter.ts): filterByType, filterBySearch, pluralToSingular mapping
  - Fetch utilities (src/utils/fetch.ts): fetchParsedResources, fetchOwnerById
  - Test suite: 175 tests across 8 test files, including integration tests with demo.eventcatalog.dev
  
### Resources List vs Resources Template List
- Because URIs are fixed (eventcatalog://events), not parameterized (eventcatalog://events/{id}/{version}), static resources are the correct MCP pattern. Templates should be used for parametrized results, for example, exposing a single event. [DOCS](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#resource-templates)
<img width="382" height="560" alt="Zrzut ekranu 2025-12-4 o 12 05 40" src="https://github.com/user-attachments/assets/9edd61ea-f660-4c4c-b302-f8c57c1c4c6d" />


### Cursor-Based Pagination
- As huge Event Catalogs may have huge LLM txt files, this easily goes above typical token/request sizes that models can consume at once. I've added a cursor-based pagination that follows basic principles to ensure that the model can iterate over all resources without issues [DOCS](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination#response-format)
<img width="609" height="379" alt="Zrzut ekranu 2025-12-4 o 12 05 59" src="https://github.com/user-attachments/assets/6e32c457-f74c-411e-ba60-d3424645458e" />

### Tests, utils, and types
Just a little refactoring to make the code more explicit, I was a little afraid of writing code without tests :) 


## What's Changed
  - Tool type params: All tools now use plural types (events, services, etc.) instead of singular
  - Version lookup: find_resource now looks up version from llms.txt when not provided (instead of defaulting to 'latest', which returned 404)
  - Consistent output format: Both find_resources tool and MCP resources now return { resources: [...] } format
  - find_owners: Fixed to return only matched owners, not all resources
  - MCP resources (src/resources/index.ts): Updated to use new filter utilities and consistent JSON format
  
  
## How was it tested?
  
### MCP Inspector - Human Checks
I'm using the `MCP Inspector` tool to preview results on the fly using the demo catalog. New tools & resources are working fine. 
  
### Agentic Integration - Model Checks
I've tested it via Claude code integration, and it uses tools & lists as expected. 
  
## Future Improvements

### Resource Templates
We may add basic resource templates to have parametrized access to each resource separately. This will allow models to access each resource directly without using tools. This will be a more model-native way of doing so, but it's not critical.
  